### PR TITLE
Fix dark mode flash on page navigation

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -52,7 +52,12 @@ const Layout = ({
   };
 
   const toggleTheme = () => {
-    setTheme((current) => (current === 'dark' ? 'light' : 'dark'));
+    setTheme((current) => {
+      const next = current === 'dark' ? 'light' : 'dark';
+      document.documentElement.dataset.theme = next;
+      try { window.localStorage.setItem('theme', next); } catch {}
+      return next;
+    });
   };
 
   useEffect(() => {
@@ -64,16 +69,6 @@ const Layout = ({
     const initialTheme = storedTheme ?? (prefersDark ? 'dark' : 'light');
     setTheme(initialTheme);
   }, []);
-
-  useEffect(() => {
-    if (typeof document === 'undefined') return;
-    document.documentElement.dataset.theme = theme;
-    try {
-      window.localStorage.setItem('theme', theme);
-    } catch {
-      // Ignore storage errors (private mode, blocked storage, etc.)
-    }
-  }, [theme]);
 
   useEffect(() => {
     if (typeof document === 'undefined') return;

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -30,6 +30,21 @@ export default class MyDocument extends Document {
           />
         </Head>
         <body>
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `
+              (function() {
+                try {
+                  var theme = localStorage.getItem('theme');
+                  if (!theme) {
+                    theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+                  }
+                  document.documentElement.dataset.theme = theme;
+                } catch (e) {}
+              })();
+            `,
+            }}
+          />
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
## Summary
- Add blocking script in `_document.tsx` that sets `data-theme` from localStorage/prefers-color-scheme **before** React hydrates — prevents flash on initial page load
- Remove the `useEffect` in `layout.tsx` that synced `data-theme` from React state on every mount — this was resetting `data-theme` to `light` on each navigation since Layout remounts per page
- Move `data-theme` and localStorage writes into `toggleTheme` directly so they only fire on user action

## Root cause
`Layout` is rendered inside each page (not in `_app.tsx`), so it remounts on every navigation. The theme state initialized as `'light'`, and a `useEffect` would set `data-theme='light'` before another `useEffect` read the stored `'dark'` preference — causing a visible light→dark flash.

## Test plan
- [ ] CI checks pass
- [ ] Toggle dark mode, navigate between pages — no flash
- [ ] Refresh page in dark mode — no flash
- [ ] Works with system prefers-color-scheme when no stored preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)