### PR TITLE
Reduce theme transition duration to 0.1s

### DIFF
--- a/components/styles/layout.css
+++ b/components/styles/layout.css
@@ -48,7 +48,7 @@
   --chat-header-bg: #154475;
 
   --transition-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
-  --transition-duration: 0.25s;
+  --transition-duration: 0.1s;
   --animation-duration: 0.25s;
 
   --background: #121212;


### PR DESCRIPTION
## Summary
- Change `--transition-duration` from `0.25s` to `0.1s` for a snappier light/dark mode toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)