### PR TITLE
ci: add Build check that runs next build on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,32 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Runs prebuild (generate:context via tsx) + `next build`, which
+      # type-checks the project. The e2e workflow only runs `next dev`, so
+      # type/build/prebuild errors (e.g. the TypeScript 6 upgrade) are invisible
+      # to it and only surface on Vercel. This job mirrors the Vercel build.
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## Why

The `e2e` workflow runs Playwright against `next dev` (see `webServer` in `playwright.config.ts`), so it never does a production `next build` or type-check. That's why the TypeScript 6 bump (#30) showed **e2e passing but Vercel failing** — the type/prebuild errors were invisible to CI and only surfaced at deploy time.

## What

Adds a standalone `Build` job that runs `npm run build` (which triggers `prebuild` → `generate:context` via tsx, then `next build` with type-checking) on every PR and push to `master`. This mirrors the Vercel build, so build/type/prebuild failures are caught on the PR.

Uses `npm ci` (matching the package-lock.json Vercel uses) on Node 22.

## Follow-up (optional, manual)

Add the new `build` check to branch protection on `master` alongside the existing `e2e` check so these failures actually block merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)