### PR TITLE
Fix UI bugs: body font fallback, metadata, mobile nav, a11y, footer

### DIFF
--- a/components/cards/cards.tsx
+++ b/components/cards/cards.tsx
@@ -93,7 +93,7 @@ function getDemoButtons(singleCard: ContentListItem) {
           href={singleCard.liveSite}
           target="_blank"
           rel="noreferrer noopener"
-          aria-label={singleCard.title}
+          aria-label={`${singleCard.title} demo`}
           className="a-demo"
         >
           <button className="demo">Demo</button>
@@ -104,7 +104,7 @@ function getDemoButtons(singleCard: ContentListItem) {
           href={singleCard.sourceCode}
           target="_blank"
           rel="noreferrer noopener"
-          aria-label={singleCard.title}
+          aria-label={`${singleCard.title} source code`}
           className="a-source"
         >
           <button className="source">Source</button>
@@ -115,7 +115,7 @@ function getDemoButtons(singleCard: ContentListItem) {
           href={singleCard.presentation}
           target="_blank"
           rel="noreferrer noopener"
-          aria-label={singleCard.title}
+          aria-label={`${singleCard.title} presentation`}
           className="a-presentation"
         >
           <button className="source">Presentation</button>

--- a/components/chat/chat-widget.styles.ts
+++ b/components/chat/chat-widget.styles.ts
@@ -5,7 +5,7 @@ export const ChatContainer = styled.div`
   bottom: 24px;
   right: 24px;
   z-index: 1000;
-  font-family: 'DM Sans', sans-serif;
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
 
   @media (max-width: 560px) {
     bottom: 16px;
@@ -94,7 +94,7 @@ export const ChatHeader = styled.div`
 
   h3 {
     margin: 0;
-    font-family: 'Manrope', sans-serif;
+    font-family: var(--font-manrope), 'Manrope', sans-serif;
     font-size: 1rem;
     font-weight: 700;
   }
@@ -175,7 +175,7 @@ export const ChatInput = styled.input`
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: 8px;
   font-size: 0.9rem;
-  font-family: 'DM Sans', sans-serif;
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
   background: var(--surface-muted, #f8f9fa);
   color: var(--text-color, #161b2f);
   transition: border-color 0.2s, background 0.2s;
@@ -205,7 +205,7 @@ export const SendButton = styled.button`
   cursor: pointer;
   font-size: 0.9rem;
   font-weight: 600;
-  font-family: 'DM Sans', sans-serif;
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
   transition: background 0.2s, transform 0.1s, filter 0.2s;
 
   &:hover:not(:disabled) {

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -81,7 +81,11 @@ const Layout = ({
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
       <MenuContext.Provider value={{ menuOpen, toggleMenuOpen }}>
         <Head>
-          <title>{`${pageTitle} | ${SiteConfig.site.siteTitle}`}</title>
+          <title>
+            {pageTitle === SiteConfig.site.siteTitle
+              ? SiteConfig.site.siteTitle
+              : `${pageTitle} | ${SiteConfig.site.siteTitle}`}
+          </title>
           <meta
             name="keywords"
             content={SiteConfig.site.keywords}
@@ -105,9 +109,10 @@ const Layout = ({
             content={SiteConfig.site.siteUrl}
             key="ogurl"
           />
+          <meta property="og:type" content="website" key="ogtype" />
           <meta
             property="og:image"
-            content={SiteConfig.site.siteImage}
+            content={`${SiteConfig.site.siteUrl}${SiteConfig.site.siteImage}`}
             key="ogimage"
           />
           <meta

--- a/components/nav/mobile-nav.tsx
+++ b/components/nav/mobile-nav.tsx
@@ -1,14 +1,9 @@
 import Link from 'next/link';
-import React, { useContext } from 'react';
+import React from 'react';
 import { StyledMobileNav } from '../styles/nav.styles';
 import { navLinks as mobileNavLinks } from './nav';
-import { ThemeContext } from '..';
-import ThemeToggle from '../theme-toggle';
 
 const MobileNav = () => {
-  const themeContext = useContext(ThemeContext);
-  const { theme, toggleTheme } = themeContext;
-
   return (
     <StyledMobileNav>
       <div className="mobile-nav-container">
@@ -33,9 +28,6 @@ const MobileNav = () => {
               </li>
             );
           })}
-          <li className="listItem">
-            <ThemeToggle isDark={theme === 'dark'} onToggle={toggleTheme} />
-          </li>
         </ul>
       </div>
     </StyledMobileNav>

--- a/components/nav/nav.tsx
+++ b/components/nav/nav.tsx
@@ -62,6 +62,8 @@ const Nav = () => {
             <StyledHamburger
               menuOpen={menuOpen}
               onClick={toggleMenuOpen}
+              aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={menuOpen}
             ></StyledHamburger>
           </div>
         </nav>

--- a/components/styles/footer.styles.ts
+++ b/components/styles/footer.styles.ts
@@ -18,10 +18,14 @@ export const StyledFooterSection = styled.footer`
   }
   .footer-container {
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
     align-items: center;
 
     padding: 20px 0px;
+  }
+
+  .footer-copyright {
+    color: var(--nav-foreground);
   }
 
   .linkedin:hover,
@@ -106,9 +110,8 @@ export const StyledFooterSection = styled.footer`
 
   .footerSocialLinks {
     display: flex;
-    margin: auto;
-    margin-bottom: 1em;
-    top: 50%;
+    margin: 0;
+    list-style: none;
   }
 
   .footerSocialLink {

--- a/components/styles/layout.css
+++ b/components/styles/layout.css
@@ -132,10 +132,16 @@ a:hover>img {
 
 /* TYPOGRAPHY */
 html {
-  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
   font-size: 17px;
   line-height: 1.5;
   color: var(--text-color);
+}
+
+/* The next/font variables are defined on the .app-root div in _app.tsx, so
+   they only resolve at or below that element — a font-family rule on <html>
+   can't see them and silently falls back to the browser default (serif). */
+.app-root {
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
 }
 
 ul,

--- a/components/styles/nav.styles.ts
+++ b/components/styles/nav.styles.ts
@@ -229,91 +229,16 @@ export const StyledMobileNav = styled.section`
   }
 
   .link {
-    font-size: 1.2em;
-  }
-
-  .themeToggle {
-    background: transparent;
-    border: none;
+    font-size: 1.4em;
+    font-family: var(--font-manrope), 'Manrope', sans-serif;
+    font-weight: 700;
     color: var(--text-color);
-    height: 2.5rem;
-    width: 4.4rem;
-    padding: 0;
-    border-radius: 999px;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+
+    &:hover {
+      color: var(--prim-color);
+    }
   }
 
-  .themeToggle-track {
-    height: 2.5rem;
-    width: 4.4rem;
-    border-radius: 999px;
-    background: var(--surface-muted);
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 0.4rem;
-    position: relative;
-  }
-
-  .themeToggle-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-color-bright);
-  }
-
-  .themeToggle-icon--sun {
-    color: #d89b11;
-  }
-
-  .themeToggle-thumb {
-    position: absolute;
-    top: 0.3rem;
-    left: 0.3rem;
-    height: 1.9rem;
-    width: 1.9rem;
-    border-radius: 50%;
-    background: #ffffff;
-    border: 1px solid rgba(0, 0, 0, 0.08);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    transition:
-      transform var(--transition-duration) var(--transition-timing-function),
-      background-color var(--transition-duration) var(--transition-timing-function);
-  }
-
-  .themeToggle-thumb svg {
-    height: 1rem;
-    width: 1rem;
-  }
-
-  .themeToggle-thumb .themeToggle-icon--moon {
-    display: none;
-  }
-
-  html[data-theme='dark'] & .themeToggle-track {
-    background: #10141c;
-    border-color: rgba(125, 177, 255, 0.35);
-  }
-
-  html[data-theme='dark'] & .themeToggle-thumb {
-    transform: translateX(1.9rem);
-    background: #253147;
-    border-color: #2e3c57;
-  }
-
-  html[data-theme='dark'] & .themeToggle-thumb .themeToggle-icon--sun {
-    display: none;
-  }
-
-  html[data-theme='dark'] & .themeToggle-thumb .themeToggle-icon--moon {
-    display: inline-flex;
-  }
 `;
 
 export const StyledHamburger = styled.button<IStyledHamburger>`

--- a/config/index.json
+++ b/config/index.json
@@ -6,11 +6,11 @@
     "description": "Hello! I’m Ryan — I love learning and building new things. Here you’ll find a collection of projects I’ve created for fun, for coursework, and some books I’ve read along the way."
   },
   "site": {
-    "siteUrl": "https://rylew.co",
+    "siteUrl": "https://www.rylew.dev",
     "siteName": "Ryan Lewis Portfolio",
     "siteTitle": "Ryan Lewis Portfolio",
     "siteDescription": "Ryan Lewis Portfolio",
     "keywords": "JavaScript, NextJS, Software Engineer, React, ReactJS Engineer San Francisco, Ryan Lewis",
-    "siteImage": "../public/Logo.png"
+    "siteImage": "/Logo.png"
   }
 }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -24,7 +24,7 @@ const manrope = Manrope({
  */
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <div className={`${dmSans.variable} ${manrope.variable}`}>
+    <div className={`${dmSans.variable} ${manrope.variable} app-root`}>
       <Component {...pageProps} />
       <Analytics />
     </div>


### PR DESCRIPTION
## Bug-fix pass (PR 1 of 3)

The biggest one: **body text has been rendering in the browser's default serif (Times), not DM Sans.** The next/font CSS variables are defined on the wrapper div in `_app.tsx`, so the `font-family` rule on `html` in `layout.css` couldn't resolve `var(--font-dm-sans)` and the whole declaration was silently discarded. The rule now lives on the wrapper (`.app-root`). Same class of bug fixed in the chat widget, which referenced literal `'DM Sans'`/`'Manrope'` names that don't match next/font's hashed families.

Also fixed:
- **Tab title duplication** — `Ryan Lewis Portfolio | Ryan Lewis Portfolio` on the home page
- **Dead `og:url`** — `siteUrl` pointed at rylew.co (no longer resolves); now `https://www.rylew.dev`
- **Broken `og:image`** — was `../public/Logo.png` (relative path, invalid for Open Graph); now absolute. Added `og:type`
- **Mobile nav menu** — links rendered as default browser hyperlinks (blue serif); now Manrope + theme colors. Removed the second theme toggle inside the menu (header toggle stays visible). Dead toggle CSS removed
- **A11y** — hamburger button had no accessible name (now aria-label + aria-expanded); card Demo/Source/Presentation links all announced the card title (now "X demo", "X source code", "X presentation")
- **Footer** — ©year was pushed to the viewport edge by `margin: auto` on the icon list; now space-between inside the container

No visual redesign here — that's PR 2 (polish) and PR 3 (refresh), stacked on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)