### PR TITLE
Design polish: card metadata alignment, flat surfaces, hero identity line

### DIFF
--- a/components/cards/cards.tsx
+++ b/components/cards/cards.tsx
@@ -93,7 +93,7 @@ function getDemoButtons(singleCard: ContentListItem) {
           href={singleCard.liveSite}
           target="_blank"
           rel="noreferrer noopener"
-          aria-label={singleCard.title}
+          aria-label={`${singleCard.title} demo`}
           className="a-demo"
         >
           <button className="demo">Demo</button>
@@ -104,7 +104,7 @@ function getDemoButtons(singleCard: ContentListItem) {
           href={singleCard.sourceCode}
           target="_blank"
           rel="noreferrer noopener"
-          aria-label={singleCard.title}
+          aria-label={`${singleCard.title} source code`}
           className="a-source"
         >
           <button className="source">Source</button>
@@ -115,7 +115,7 @@ function getDemoButtons(singleCard: ContentListItem) {
           href={singleCard.presentation}
           target="_blank"
           rel="noreferrer noopener"
-          aria-label={singleCard.title}
+          aria-label={`${singleCard.title} presentation`}
           className="a-presentation"
         >
           <button className="source">Presentation</button>

--- a/components/chat/chat-widget.styles.ts
+++ b/components/chat/chat-widget.styles.ts
@@ -5,7 +5,7 @@ export const ChatContainer = styled.div`
   bottom: 24px;
   right: 24px;
   z-index: 1000;
-  font-family: 'DM Sans', sans-serif;
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
 
   @media (max-width: 560px) {
     bottom: 16px;
@@ -94,7 +94,7 @@ export const ChatHeader = styled.div`
 
   h3 {
     margin: 0;
-    font-family: 'Manrope', sans-serif;
+    font-family: var(--font-manrope), 'Manrope', sans-serif;
     font-size: 1rem;
     font-weight: 700;
   }
@@ -175,7 +175,7 @@ export const ChatInput = styled.input`
   border: 1px solid var(--border-color, #dee2e6);
   border-radius: 8px;
   font-size: 0.9rem;
-  font-family: 'DM Sans', sans-serif;
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
   background: var(--surface-muted, #f8f9fa);
   color: var(--text-color, #161b2f);
   transition: border-color 0.2s, background 0.2s;
@@ -205,7 +205,7 @@ export const SendButton = styled.button`
   cursor: pointer;
   font-size: 0.9rem;
   font-weight: 600;
-  font-family: 'DM Sans', sans-serif;
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
   transition: background 0.2s, transform 0.1s, filter 0.2s;
 
   &:hover:not(:disabled) {

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -81,7 +81,11 @@ const Layout = ({
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
       <MenuContext.Provider value={{ menuOpen, toggleMenuOpen }}>
         <Head>
-          <title>{`${pageTitle} | ${SiteConfig.site.siteTitle}`}</title>
+          <title>
+            {pageTitle === SiteConfig.site.siteTitle
+              ? SiteConfig.site.siteTitle
+              : `${pageTitle} | ${SiteConfig.site.siteTitle}`}
+          </title>
           <meta
             name="keywords"
             content={SiteConfig.site.keywords}
@@ -105,9 +109,10 @@ const Layout = ({
             content={SiteConfig.site.siteUrl}
             key="ogurl"
           />
+          <meta property="og:type" content="website" key="ogtype" />
           <meta
             property="og:image"
-            content={SiteConfig.site.siteImage}
+            content={`${SiteConfig.site.siteUrl}${SiteConfig.site.siteImage}`}
             key="ogimage"
           />
           <meta

--- a/components/nav/mobile-nav.tsx
+++ b/components/nav/mobile-nav.tsx
@@ -1,14 +1,9 @@
 import Link from 'next/link';
-import React, { useContext } from 'react';
+import React from 'react';
 import { StyledMobileNav } from '../styles/nav.styles';
 import { navLinks as mobileNavLinks } from './nav';
-import { ThemeContext } from '..';
-import ThemeToggle from '../theme-toggle';
 
 const MobileNav = () => {
-  const themeContext = useContext(ThemeContext);
-  const { theme, toggleTheme } = themeContext;
-
   return (
     <StyledMobileNav>
       <div className="mobile-nav-container">
@@ -33,9 +28,6 @@ const MobileNav = () => {
               </li>
             );
           })}
-          <li className="listItem">
-            <ThemeToggle isDark={theme === 'dark'} onToggle={toggleTheme} />
-          </li>
         </ul>
       </div>
     </StyledMobileNav>

--- a/components/nav/nav.tsx
+++ b/components/nav/nav.tsx
@@ -62,6 +62,8 @@ const Nav = () => {
             <StyledHamburger
               menuOpen={menuOpen}
               onClick={toggleMenuOpen}
+              aria-label={menuOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={menuOpen}
             ></StyledHamburger>
           </div>
         </nav>

--- a/components/styles/cards.styles.ts
+++ b/components/styles/cards.styles.ts
@@ -13,16 +13,18 @@ export const StyledCards = styled.section`
   }
 
   .card-demo-link {
-    margin: 10px 10px;
+    display: flex;
+    align-items: center;
+    gap: 0.3em;
+    margin-bottom: 0.5em;
 
-    a {
-      float: right;
-      margin-left: 1px;
+    time {
+      margin-right: auto;
     }
 
     button {
-      background: var(--button-bg) !important;
-      background-image: var(--button-bg) !important;
+      background: var(--button-bg);
+      border: 1px solid var(--border-color);
       border-radius: 5px;
       padding: 4px 10px;
       font-weight: bold;

--- a/components/styles/footer.styles.ts
+++ b/components/styles/footer.styles.ts
@@ -18,10 +18,14 @@ export const StyledFooterSection = styled.footer`
   }
   .footer-container {
     display: flex;
-    justify-content: center;
+    justify-content: space-between;
     align-items: center;
 
     padding: 20px 0px;
+  }
+
+  .footer-copyright {
+    color: var(--nav-foreground);
   }
 
   .linkedin:hover,
@@ -106,9 +110,8 @@ export const StyledFooterSection = styled.footer`
 
   .footerSocialLinks {
     display: flex;
-    margin: auto;
-    margin-bottom: 1em;
-    top: 50%;
+    margin: 0;
+    list-style: none;
   }
 
   .footerSocialLink {

--- a/components/styles/layout.css
+++ b/components/styles/layout.css
@@ -132,10 +132,16 @@ a:hover>img {
 
 /* TYPOGRAPHY */
 html {
-  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
   font-size: 17px;
   line-height: 1.5;
   color: var(--text-color);
+}
+
+/* The next/font variables are defined on the .app-root div in _app.tsx, so
+   they only resolve at or below that element — a font-family rule on <html>
+   can't see them and silently falls back to the browser default (serif). */
+.app-root {
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
 }
 
 ul,

--- a/components/styles/layout.css
+++ b/components/styles/layout.css
@@ -23,11 +23,11 @@
   --link-hover: #1a272c;
   --nav-foreground: #1b2430;
   --nav-link-hover: #0b0f16;
-  --nav-bg: url('/cork-wallet.png');
-  --footer-bg: url('/cork-wallet.png');
+  --nav-bg: #f0eee8;
+  --footer-bg: #f0eee8;
   --table-head-bg: #42485f;
   --table-head-text: #ffffff;
-  --button-bg: url('/cork-wallet.png');
+  --button-bg: #eceae3;
   --button-bg-hover: #0e78aa;
   --button-text: #0b0f16;
   --button-text-hover: #ffffff;
@@ -71,10 +71,8 @@ html[data-theme='dark'] {
   --link-hover: #b9d2ff;
   --nav-foreground: #f0f2f7;
   --nav-link-hover: #ffffff;
-  --nav-bg: linear-gradient(rgba(10, 12, 16, 0.75), rgba(10, 12, 16, 0.75)),
-    url('/cork-wallet.png');
-  --footer-bg: linear-gradient(rgba(10, 12, 16, 0.8), rgba(10, 12, 16, 0.8)),
-    url('/cork-wallet.png');
+  --nav-bg: #141821;
+  --footer-bg: #141821;
   --table-head-bg: #2a2f3a;
   --table-head-text: #f0f2f7;
   --button-bg: #1f2430;
@@ -307,15 +305,13 @@ p em {
 
 .meta-row {
   display: flex;
-  justify-content: space-around;
-  padding: 0 1rem;
+  align-items: center;
+  gap: 0.75em;
   margin-bottom: 0.5em;
-  /* font-size: 0.9rem;
-  color: #666; */
 }
 
 .meta-row span {
   font-weight: 500;
-  margin-right: 5rem;
-  color: var(--text-color);
+  color: var(--text-color-dark);
+  font-size: 0.9em;
 }

--- a/components/styles/nav.styles.ts
+++ b/components/styles/nav.styles.ts
@@ -229,91 +229,16 @@ export const StyledMobileNav = styled.section`
   }
 
   .link {
-    font-size: 1.2em;
-  }
-
-  .themeToggle {
-    background: transparent;
-    border: none;
+    font-size: 1.4em;
+    font-family: var(--font-manrope), 'Manrope', sans-serif;
+    font-weight: 700;
     color: var(--text-color);
-    height: 2.5rem;
-    width: 4.4rem;
-    padding: 0;
-    border-radius: 999px;
-    cursor: pointer;
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
+
+    &:hover {
+      color: var(--prim-color);
+    }
   }
 
-  .themeToggle-track {
-    height: 2.5rem;
-    width: 4.4rem;
-    border-radius: 999px;
-    background: var(--surface-muted);
-    border: 1px solid rgba(255, 255, 255, 0.25);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 0.4rem;
-    position: relative;
-  }
-
-  .themeToggle-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--text-color-bright);
-  }
-
-  .themeToggle-icon--sun {
-    color: #d89b11;
-  }
-
-  .themeToggle-thumb {
-    position: absolute;
-    top: 0.3rem;
-    left: 0.3rem;
-    height: 1.9rem;
-    width: 1.9rem;
-    border-radius: 50%;
-    background: #ffffff;
-    border: 1px solid rgba(0, 0, 0, 0.08);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    transition:
-      transform var(--transition-duration) var(--transition-timing-function),
-      background-color var(--transition-duration) var(--transition-timing-function);
-  }
-
-  .themeToggle-thumb svg {
-    height: 1rem;
-    width: 1rem;
-  }
-
-  .themeToggle-thumb .themeToggle-icon--moon {
-    display: none;
-  }
-
-  html[data-theme='dark'] & .themeToggle-track {
-    background: #10141c;
-    border-color: rgba(125, 177, 255, 0.35);
-  }
-
-  html[data-theme='dark'] & .themeToggle-thumb {
-    transform: translateX(1.9rem);
-    background: #253147;
-    border-color: #2e3c57;
-  }
-
-  html[data-theme='dark'] & .themeToggle-thumb .themeToggle-icon--sun {
-    display: none;
-  }
-
-  html[data-theme='dark'] & .themeToggle-thumb .themeToggle-icon--moon {
-    display: inline-flex;
-  }
 `;
 
 export const StyledHamburger = styled.button<IStyledHamburger>`

--- a/config/index.json
+++ b/config/index.json
@@ -6,11 +6,11 @@
     "description": "Hello! I’m Ryan — I love learning and building new things. Here you’ll find a collection of projects I’ve created for fun, for coursework, and some books I’ve read along the way."
   },
   "site": {
-    "siteUrl": "https://rylew.co",
+    "siteUrl": "https://www.rylew.dev",
     "siteName": "Ryan Lewis Portfolio",
     "siteTitle": "Ryan Lewis Portfolio",
     "siteDescription": "Ryan Lewis Portfolio",
     "keywords": "JavaScript, NextJS, Software Engineer, React, ReactJS Engineer San Francisco, Ryan Lewis",
-    "siteImage": "../public/Logo.png"
+    "siteImage": "/Logo.png"
   }
 }

--- a/config/index.json
+++ b/config/index.json
@@ -3,7 +3,7 @@
     "name": "Ryan Lewis",
     "title": "Ryan Lewis Portfolio",
     "twitterHandle": "@rylew312",
-    "description": "Hello! I’m Ryan — I love learning and building new things. Here you’ll find a collection of projects I’ve created for fun, for coursework, and some books I’ve read along the way."
+    "description": "Hello! I’m Ryan — a software engineer who loves learning and building new things. Here you’ll find a collection of projects I’ve created for fun, for coursework, and some books I’ve read along the way."
   },
   "site": {
     "siteUrl": "https://www.rylew.dev",

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -24,7 +24,7 @@ const manrope = Manrope({
  */
 function MyApp({ Component, pageProps }: AppProps) {
   return (
-    <div className={`${dmSans.variable} ${manrope.variable}`}>
+    <div className={`${dmSans.variable} ${manrope.variable} app-root`}>
       <Component {...pageProps} />
       <Analytics />
     </div>


### PR DESCRIPTION
## Design polish (PR 2 of 3 — stacked on #39)

**Base is `fix/ui-bug-pass`** — merge #39 first; this PR then retargets to master automatically.

Three surgical changes, no structural redesign:

1. **Card metadata alignment** — date + "Book Review" label now cluster left with consistent spacing (was `space-around` + a hard-coded `5rem` margin, which wandered per card and let labels bleed into the neighboring card). Demo/Source/Presentation buttons right-align and get a border instead of texture.
2. **Cork texture retired** — nav, footer, and buttons now use flat colors from the existing theme variables (warm neutral `#f0eee8` light / raised `#141821` dark). Pure CSS-variable swap.
3. **Hero identity line** — home intro now opens "Hello! I'm Ryan — a software engineer who loves learning and building new things…" so visitors learn what you do without clicking About.

Verified with a local production build + screenshots at each step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)