### PR TITLE
Color-code card action buttons and tag chips by category

### DIFF
--- a/components/cards/cards.tsx
+++ b/components/cards/cards.tsx
@@ -123,7 +123,7 @@ function getDemoButtons(singleCard: ContentListItem) {
           aria-label={`${singleCard.title} presentation`}
           className="a-presentation"
         >
-          <button className="source">Presentation</button>
+          <button className="presentation">Presentation</button>
         </a>
       )}
     </>

--- a/components/chips/chips.tsx
+++ b/components/chips/chips.tsx
@@ -1,17 +1,40 @@
 import Link from 'next/link';
 import React from 'react';
 import { StyledChip } from '../styles/chips.styles';
+import tagsJSON from '../../config/tags.json';
 
 interface ChipsProps {
   items: string[];
 }
+
+export const TAG_CATEGORIES = [
+  'language',
+  'framework',
+  'ml',
+  'practice',
+  'domain',
+] as const;
+
+export type TagCategory = (typeof TAG_CATEGORIES)[number];
+
+const FALLBACK_CATEGORY: TagCategory = 'domain';
+
+const categoryByTag = new Map<string, TagCategory>(
+  tagsJSON.map((entry) => [entry.tag, entry.category as TagCategory]),
+);
+
+// A tag added to a markdown file but not yet to config/tags.json falls back to
+// the neutral category rather than rendering unstyled. tag-pages.spec.ts turns
+// that omission into a test failure so it can't go unnoticed.
+export const getTagCategory = (tag: string): TagCategory =>
+  categoryByTag.get(tag) ?? FALLBACK_CATEGORY;
 
 export const Chips = ({ items }: ChipsProps) => {
   return (
     <StyledChip>
       <ul>
         {items.map((tag: string, index: number) => (
-          <li key={index}>
+          <li key={index} className={getTagCategory(tag)}>
             <Link href={`tags/${tag}`}>{tag}</Link>
           </li>
         ))}

--- a/components/styles/cards.styles.ts
+++ b/components/styles/cards.styles.ts
@@ -85,6 +85,42 @@ export const StyledCards = styled.section`
         color: var(--button-text-hover);
       }
     }
+
+    /* Each action carries its own colour so a row of cards can be scanned for
+       "has a live demo" without reading the labels. Hover fills with the
+       darker -text shade rather than the border hue, which would fail AA. */
+    button.demo {
+      background: var(--action-demo-bg);
+      border-color: var(--action-demo-border);
+      color: var(--action-demo-text);
+
+      &:hover {
+        background: var(--action-demo-text);
+        color: var(--action-text-hover);
+      }
+    }
+
+    button.source {
+      background: var(--action-source-bg);
+      border-color: var(--action-source-border);
+      color: var(--action-source-text);
+
+      &:hover {
+        background: var(--action-source-text);
+        color: var(--action-text-hover);
+      }
+    }
+
+    button.presentation {
+      background: var(--action-presentation-bg);
+      border-color: var(--action-presentation-border);
+      color: var(--action-presentation-text);
+
+      &:hover {
+        background: var(--action-presentation-text);
+        color: var(--action-text-hover);
+      }
+    }
   }
 
   h2 {

--- a/components/styles/chips.styles.ts
+++ b/components/styles/chips.styles.ts
@@ -43,4 +43,57 @@ export const StyledChip = styled.div<IContainer>`
   li:hover {
     box-shadow: 0 0 4px 2px var(--chip-shadow);
   }
+
+  /* Tags are coloured by category rather than individually, so adding a tag to
+     an existing category needs no style change. The category comes from
+     config/tags.json via getTagCategory. */
+  li.language {
+    background: var(--tag-language-bg);
+    border-color: var(--tag-language-border);
+
+    a,
+    a:hover {
+      color: var(--tag-language-text);
+    }
+  }
+
+  li.framework {
+    background: var(--tag-framework-bg);
+    border-color: var(--tag-framework-border);
+
+    a,
+    a:hover {
+      color: var(--tag-framework-text);
+    }
+  }
+
+  li.ml {
+    background: var(--tag-ml-bg);
+    border-color: var(--tag-ml-border);
+
+    a,
+    a:hover {
+      color: var(--tag-ml-text);
+    }
+  }
+
+  li.practice {
+    background: var(--tag-practice-bg);
+    border-color: var(--tag-practice-border);
+
+    a,
+    a:hover {
+      color: var(--tag-practice-text);
+    }
+  }
+
+  li.domain {
+    background: var(--tag-domain-bg);
+    border-color: var(--tag-domain-border);
+
+    a,
+    a:hover {
+      color: var(--tag-domain-text);
+    }
+  }
 `;

--- a/components/styles/layout.css
+++ b/components/styles/layout.css
@@ -47,6 +47,39 @@
   --callout-presentation: #e46a3a;
   --chat-header-bg: #154475;
 
+  /* Card action buttons. Each action reuses its --callout-* hue as the border,
+     so a card button and the matching callout icon on the detail page read as
+     the same signal. -text doubles as the hover fill: white on the base hue is
+     only ~3.3:1, white on the darker -text shade clears AA. */
+  --action-demo-bg: #eaf1fa;
+  --action-demo-border: #3a7bd5;
+  --action-demo-text: #20507f;
+  --action-source-bg: #e7f4ee;
+  --action-source-border: #2e9e6f;
+  --action-source-text: #1c6446;
+  --action-presentation-bg: #fbeee8;
+  --action-presentation-border: #e46a3a;
+  --action-presentation-text: #9a4321;
+  --action-text-hover: #ffffff;
+
+  /* Tag chip categories. Hues stay clear of the three action colors above so
+     the two systems never read as the same signal. */
+  --tag-language-bg: #efeafc;
+  --tag-language-border: #8b74e8;
+  --tag-language-text: #4a35a8;
+  --tag-framework-bg: #e3f4f1;
+  --tag-framework-border: #3aa596;
+  --tag-framework-text: #1f6a5f;
+  --tag-ml-bg: #fbeaf1;
+  --tag-ml-border: #d4537e;
+  --tag-ml-text: #932f52;
+  --tag-practice-bg: #fbf0dc;
+  --tag-practice-border: #c8871f;
+  --tag-practice-text: #7d5209;
+  --tag-domain-bg: #eceef2;
+  --tag-domain-border: #8b95a7;
+  --tag-domain-text: #46505f;
+
   --transition-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
   --transition-duration: 0.1s;
   --animation-duration: 0.25s;
@@ -95,6 +128,35 @@ html[data-theme='dark'] {
   --callout-source: #65d6a0;
   --callout-presentation: #ff9a6a;
   --chat-header-bg: #1e3a5f;
+
+  /* Dark mode inverts the hover pairing: the fill is the light hue and the
+     label goes dark, so --action-text-hover flips to near-black. */
+  --action-demo-bg: #1a2433;
+  --action-demo-border: #7db1ff;
+  --action-demo-text: #9cc2ff;
+  --action-source-bg: #172a24;
+  --action-source-border: #65d6a0;
+  --action-source-text: #65d6a0;
+  --action-presentation-bg: #2b2019;
+  --action-presentation-border: #ff9a6a;
+  --action-presentation-text: #ff9a6a;
+  --action-text-hover: #0b0f16;
+
+  --tag-language-bg: #241f3d;
+  --tag-language-border: #9d8bf0;
+  --tag-language-text: #b9aaf7;
+  --tag-framework-bg: #14302c;
+  --tag-framework-border: #4cc3b0;
+  --tag-framework-text: #6fd8c6;
+  --tag-ml-bg: #33202a;
+  --tag-ml-border: #e07a9f;
+  --tag-ml-text: #f0a3bd;
+  --tag-practice-bg: #332715;
+  --tag-practice-border: #d9a04a;
+  --tag-practice-text: #edbf72;
+  --tag-domain-bg: #232833;
+  --tag-domain-border: #7d8798;
+  --tag-domain-text: #a3adbd;
 }
 
 /* LINKS */

--- a/config/tags.json
+++ b/config/tags.json
@@ -2,136 +2,163 @@
   {
     "tag": "javascript",
     "title": "JavaScript",
-    "description": "All things javascript"
+    "description": "All things javascript",
+    "category": "language"
   },
   {
     "tag": "sklearn",
     "title": "sklearn",
-    "description": "scikit-learn learnings"
+    "description": "scikit-learn learnings",
+    "category": "ml"
   },
   {
     "tag": "python",
     "title": "Python",
-    "description": "One of the greatest languages ever!"
+    "description": "One of the greatest languages ever!",
+    "category": "language"
   },
   {
     "tag": "machine learning",
     "title": "Machine Learning",
-    "description": "Machine Learning and Data Science topics"
+    "description": "Machine Learning and Data Science topics",
+    "category": "ml"
   },
   {
     "tag": "angular",
     "title": "Angular",
-    "description": "All things angular"
+    "description": "All things angular",
+    "category": "framework"
   },
   {
     "tag": "react",
     "title": "React",
-    "description": "All things React"
+    "description": "All things React",
+    "category": "framework"
   },
   {
     "tag": "flask",
     "title": "Flask",
-    "description": "All things Python Flask related"
+    "description": "All things Python Flask related",
+    "category": "framework"
   },
   {
     "tag": "omscs",
     "title": "OMSCS",
-    "description": "All things related to my OMSCS masters program"
+    "description": "All things related to my OMSCS masters program",
+    "category": "domain"
   },
   {
     "tag": "edtech",
     "title": "EdTech",
-    "description": "Everything education technology related"
+    "description": "Everything education technology related",
+    "category": "domain"
   },
   {
     "tag": "management",
     "title": "Management",
-    "description": "Everything management related"
+    "description": "Everything management related",
+    "category": "practice"
   },
   {
     "tag": "engineering",
     "title": "Engineering",
-    "description": "Everything engineering related"
+    "description": "Everything engineering related",
+    "category": "practice"
   },
   {
     "tag": "clustering",
     "title": "Clustering",
-    "description": "Clustering techniques and projects"
+    "description": "Clustering techniques and projects",
+    "category": "ml"
   },
   {
     "tag": "d3",
     "title": "D3",
-    "description": "Data visualization with D3"
+    "description": "Data visualization with D3",
+    "category": "framework"
   },
   {
     "tag": "devops",
     "title": "DevOps",
-    "description": "DevOps practices and tooling"
+    "description": "DevOps practices and tooling",
+    "category": "practice"
   },
   {
     "tag": "dimensionality reduction",
     "title": "Dimensionality Reduction",
-    "description": "Dimensionality reduction techniques"
+    "description": "Dimensionality reduction techniques",
+    "category": "ml"
   },
   {
     "tag": "django",
     "title": "Django",
-    "description": "Django projects and learnings"
+    "description": "Django projects and learnings",
+    "category": "framework"
   },
   {
     "tag": "fullstack",
     "title": "Full Stack",
-    "description": "Full stack projects and notes"
+    "description": "Full stack projects and notes",
+    "category": "practice"
   },
   {
     "tag": "graphql",
     "title": "GraphQL",
-    "description": "GraphQL APIs and clients"
+    "description": "GraphQL APIs and clients",
+    "category": "framework"
   },
   {
     "tag": "mdp",
     "title": "MDP",
-    "description": "Markov Decision Processes"
+    "description": "Markov Decision Processes",
+    "category": "ml"
   },
   {
     "tag": "optimization",
     "title": "Optimization",
-    "description": "Optimization techniques and studies"
+    "description": "Optimization techniques and studies",
+    "category": "ml"
   },
   {
     "tag": "policy iteration",
     "title": "Policy Iteration",
-    "description": "Policy iteration methods"
+    "description": "Policy iteration methods",
+    "category": "ml"
   },
   {
     "tag": "postgres",
     "title": "Postgres",
-    "description": "PostgreSQL development"
+    "description": "PostgreSQL development",
+    "category": "framework"
   },
   {
     "tag": "q-learning",
     "title": "Q-Learning",
-    "description": "Q-learning and reinforcement learning"
+    "description": "Q-learning and reinforcement learning",
+    "category": "ml"
   },
   {
     "tag": "randomized algorithms",
     "title": "Randomized Algorithms",
-    "description": "Randomized algorithms and experiments"
+    "description": "Randomized algorithms and experiments",
+    "category": "ml"
   },
   {
     "tag": "reinforcement learning",
     "title": "Reinforcement Learning",
-    "description": "Reinforcement learning topics"
+    "description": "Reinforcement learning topics",
+    "category": "ml"
   },
   {
     "tag": "value iteration",
     "title": "Value Iteration",
-    "description": "Value iteration methods"
+    "description": "Value iteration methods",
+    "category": "ml"
   },
   {
     "tag": "vue",
     "title": "Vue",
-    "description": "Vue projects and notes"
+    "description": "Vue projects and notes",
+    "category": "framework"
   }
 ]

--- a/tests/tag-pages.spec.ts
+++ b/tests/tag-pages.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import tagsJSON from "../config/tags.json";
 import { getContentList, getContentWithTag } from "../lib/content";
+import { TAG_CATEGORIES } from "../components/chips/chips";
 
 const siteTags = new Set(tagsJSON.map((tag) => tag.tag));
 
@@ -106,5 +107,14 @@ test("all content tags exist in config/tags.json", async () => {
 
   for (const tag of contentTags) {
     expect(siteTags.has(tag)).toBeTruthy();
+  }
+});
+
+test("every tag in config/tags.json has a known category", async () => {
+  for (const entry of tagsJSON) {
+    expect(
+      TAG_CATEGORIES,
+      `tag "${entry.tag}" has category "${entry.category}"`
+    ).toContain(entry.category);
   }
 });


### PR DESCRIPTION
## What

`Demo` / `Source` / `Presentation` on project cards all rendered as one uniform gray, and all 27 topic tags shared a single chip style. Neither could be scanned without reading the labels. Both now carry colour.

## Where the colours come from

The site already defined `--callout-{demo,source,presentation}` — used today only for the small icons inside markdown callouts on detail pages. Rather than invent a palette, those hues now drive the card buttons too, so a card button and its matching callout icon read as the same signal.

Each action gets a `-bg` / `-border` / `-text` set in both themes. Hover fills with the darker `-text` shade rather than the border hue, because white on the base hue only reaches ~3.3:1 — below AA.

Tags are coloured by **category**, not individually, so adding a tag to an existing category needs no style change:

| Category | Colour | Tags |
|---|---|---|
| Language | violet | python, javascript |
| Framework and tooling | teal | react, vue, angular, django, flask, graphql, postgres, d3 |
| ML and algorithms | pink | machine learning, reinforcement learning, q-learning, mdp, clustering, optimization, sklearn, dimensionality reduction, policy iteration, value iteration, randomized algorithms |
| Practice | amber | engineering, management, devops, fullstack |
| Domain | slate | omscs, edtech |

Tag hues stay clear of the three action hues so the two systems never read as the same signal.

## Where the data lives

The category goes in `config/tags.json`, alongside the `title` and `description` already there — no parallel map to drift out of sync. An unknown tag falls back to the neutral `domain` style rather than rendering unstyled, and a new test makes an unrecognised category a failure rather than a silent gray chip.

## Drive-by fix

The Presentation button rendered `className="source"`. Inert before, but it would have silently picked up the green Source colour the moment colour was attached.

## Verification

- `npm run build` passes.
- Full Playwright suite: 10/10 pass, including the axe accessibility suite across **both** themes.
- All 22 foreground/background pairs computed against WCAG AA (4.5:1); lowest is 5.62, hover states 6.56–9.25.

## Not included

Colour only. No layout changes — `chips.styles.ts` still has a crufty `float: right; margin-right: 54px`, left alone deliberately. Formatting also left alone: all 7 touched files were already prettier-nonconforming on `master` (43 files repo-wide), so reformatting would have buried the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)