### PR TITLE
Rewrite About into a professional page, sourced from me/profile.json

### DIFF
--- a/components/header/about-header.tsx
+++ b/components/header/about-header.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { profile } from '../../lib/profile';
 import { Container } from '../container';
 import { StyledPageHeading } from '../styles/header.styles';
 
@@ -6,7 +7,7 @@ const AboutHeader = () => (
   <StyledPageHeading aria-label="Page heading">
     <Container>
       <div className="header-container">
-        <h1 className="about-header">About Me</h1>
+        <h1 className="about-header">About {profile.name}</h1>
       </div>
     </Container>
   </StyledPageHeading>

--- a/components/nav/nav.tsx
+++ b/components/nav/nav.tsx
@@ -3,15 +3,29 @@ import { useRouter } from 'next/router';
 import React, { useContext } from 'react';
 import { MenuContext, ThemeContext } from '..';
 import SiteConfig from '../../config/index.json';
+import { profile } from '../../lib/profile';
 import { Container } from '../container';
 import Logo from '../logo';
 import { NavSection, StyledHamburger } from '../styles/nav.styles';
 import ThemeToggle from '../theme-toggle';
 
-export const navLinks = [
+interface NavLink {
+  title: string;
+  /** Internal route, rendered with next/link and marked active on match. */
+  link?: string;
+  /** External or static-asset URL, rendered as a new-tab anchor. */
+  href?: string;
+}
+
+// The résumé entry appears only once links.resume is set in me/profile.json,
+// so the nav can never point at a PDF that hasn't been added to public/.
+export const navLinks: NavLink[] = [
   { title: 'Projects', link: '/projects' },
   { title: 'Books', link: '/books' },
   { title: 'About', link: '/about' },
+  ...(profile.links.resume
+    ? [{ title: 'Resume', href: profile.links.resume }]
+    : []),
   {
     title: 'Source',
     href: 'https://github.com/rylew2/portfolio-rylew',

--- a/components/styles/about.styles.ts
+++ b/components/styles/about.styles.ts
@@ -48,9 +48,21 @@ export const StyledAbout = styled.section`
     }
   }
 
+  .resumeLink {
+    display: inline-block;
+    padding: 0.4em 0.9em;
+    border: 1px solid var(--border-color);
+    color: var(--prim-color);
+    font-weight: 600;
+    text-decoration: none;
+
+    &:hover {
+      border-color: var(--prim-color);
+    }
+  }
+
   .timeline,
-  .credentials,
-  .contactList {
+  .credentials {
     list-style-type: none;
     padding-left: 0;
     margin: 0;
@@ -129,12 +141,6 @@ export const StyledAbout = styled.section`
       border: 1px solid var(--chip-border);
       color: var(--chip-text);
     }
-  }
-
-  .contactList {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 0.5em 1.25em;
   }
 
   @media (max-width: 759px) {

--- a/components/styles/about.styles.ts
+++ b/components/styles/about.styles.ts
@@ -1,13 +1,18 @@
 import styled from '@emotion/styled';
 export const StyledAbout = styled.section`
+  /* The intro is a two-column row rather than a floated avatar. A float would
+     wrap the sections below the intro around the image as well. */
+  .aboutIntro {
+    display: flex;
+    align-items: flex-start;
+    gap: 1.75em;
+  }
+
   .avatarImage {
-    float: left;
-    shape-outside: circle(50%);
+    flex: 0 0 auto;
     border-radius: 50%;
     width: 200px;
     height: 200px;
-    margin-right: 1em;
-    margin-bottom: 1em; // Ensure there's space below the image when text wraps under it
 
     img {
       border-radius: 50%;
@@ -17,11 +22,148 @@ export const StyledAbout = styled.section`
     }
   }
 
+  .introText {
+    flex: 1 1 auto;
+
+    p {
+      margin-top: 0;
+    }
+  }
+
+  .positioning {
+    font-weight: 600;
+    font-size: 1.1em;
+    color: var(--prim-color);
+    margin-bottom: 0.6em;
+  }
+
+  .aboutSection {
+    margin-top: 2.5em;
+
+    h2 {
+      font-size: 1.25em;
+      margin-bottom: 0.4em;
+      padding-bottom: 0.3em;
+      border-bottom: 2px solid var(--border-color);
+    }
+  }
+
+  .timeline,
+  .credentials,
+  .contactList {
+    list-style-type: none;
+    padding-left: 0;
+    margin: 0;
+  }
+
+  .timeline li,
+  .credentials li {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.2em 0.75em;
+    padding: 0.7em 0;
+    border-bottom: 1px solid var(--border-color);
+  }
+
+  .timeline li:last-child,
+  .credentials li:last-child {
+    border-bottom: none;
+  }
+
+  .entryPrimary {
+    font-weight: 600;
+  }
+
+  .entrySecondary,
+  .entryMeta {
+    color: var(--text-color-bright);
+  }
+
+  .entryMeta {
+    margin-left: auto;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .skillGroups {
+    margin: 0;
+  }
+
+  .skillGroup {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    gap: 0.4em 1em;
+    padding: 0.6em 0;
+    border-bottom: 1px solid var(--border-color);
+
+    &:last-child {
+      border-bottom: none;
+    }
+
+    dt {
+      flex: 0 0 9em;
+      font-weight: 600;
+    }
+
+    dd {
+      flex: 1 1 12em;
+      margin: 0;
+    }
+  }
+
+  /* Matches the tag chips elsewhere on the site, minus the link behaviour. */
+  .skillPills {
+    list-style-type: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4em;
+    padding-left: 0;
+    margin: 0;
+
+    li {
+      font-size: 0.85em;
+      padding: 0.25em 0.55em;
+      background: var(--chip-bg);
+      border: 1px solid var(--chip-border);
+      color: var(--chip-text);
+    }
+  }
+
+  .contactList {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5em 1.25em;
+  }
+
   @media (max-width: 759px) {
+    .aboutIntro {
+      flex-direction: column;
+      align-items: center;
+      gap: 1em;
+      text-align: left;
+    }
+
     .avatarImage {
-      width: 150px; // Smaller size for narrow screens
+      width: 150px;
       height: 150px;
-      margin-right: 1em;
+    }
+
+    /* Stacked rows read better than a squeezed two-column layout, so the date
+       column drops below the entry instead of being pushed to the right edge. */
+    .timeline li,
+    .credentials li {
+      flex-direction: column;
+      gap: 0.15em;
+    }
+
+    .entryMeta {
+      margin-left: 0;
+    }
+
+    .skillGroup dt {
+      flex-basis: 100%;
     }
   }
 `;

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -17,7 +17,8 @@ export interface Education {
 
 export interface Certification {
   name: string;
-  issued: string;
+  /** Optional: not every certification is worth dating on the page. */
+  issued?: string;
 }
 
 export interface SkillGroup {

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -1,0 +1,60 @@
+import profileJson from '../me/profile.json';
+
+export interface Experience {
+  company: string;
+  title: string;
+  start: string;
+  end: string;
+}
+
+export interface Education {
+  school: string;
+  credential: string;
+  years?: string;
+  detail?: string;
+  coursework?: string[];
+}
+
+export interface Certification {
+  name: string;
+  issued: string;
+}
+
+export interface SkillGroup {
+  group: string;
+  items: string[];
+}
+
+export interface Volunteering {
+  organization: string;
+  dates: string;
+  description: string;
+}
+
+export interface Profile {
+  name: string;
+  role: string;
+  location: string;
+  bio: string[];
+  experience: Experience[];
+  education: Education[];
+  certifications: Certification[];
+  skills: SkillGroup[];
+  volunteering: Volunteering[];
+  interests: string[];
+  links: {
+    linkedin: string;
+    github: string;
+    email: string;
+    /** Null until a résumé PDF is added to public/. Nullable so the About page
+     *  and the nav link stay hidden rather than pointing at a 404. */
+    resume: string | null;
+  };
+}
+
+/**
+ * me/profile.json is the single source of truth for biographical facts. It also
+ * generates me/summary.txt, which is what the chat API feeds the model — see
+ * scripts/generate-summary.ts.
+ */
+export const profile = profileJson as Profile;

--- a/me/profile.json
+++ b/me/profile.json
@@ -81,8 +81,7 @@
         "JavaScript",
         "Next.js",
         "Vue.js",
-        "Redux",
-        "GraphQL (Apollo Client)"
+        "Redux"
       ]
     },
     {
@@ -91,12 +90,13 @@
     },
     {
       "group": "Databases",
-      "items": ["PostgreSQL", "SQL"]
+      "items": ["PostgreSQL"]
     },
     {
       "group": "Tools",
       "items": [
         "Docker",
+        "Colima",
         "Git",
         "Jest",
         "React Testing Library",

--- a/me/profile.json
+++ b/me/profile.json
@@ -4,7 +4,7 @@
   "location": "Brooklyn, New York",
   "bio": [
     "I'm a senior software engineer based in Brooklyn. I work across the stack — React, TypeScript, and Next.js on the front end, Python and Node services behind them. I care deeply about clean, maintainable code, collaborative problem-solving, and continuous learning.",
-    "Most of my work has been in regulated and public-interest domains: government services at Nava, banking at Wells Fargo, and health research at Kaiser Permanente. In those settings reliability and accessibility aren't finishing touches, which has shaped how I approach everything else.",
+    "Most of my work has been in regulated and public-interest domains: government services at Nava, banking at Wells Fargo, and health research at Kaiser Permanente.",
     "Outside of work I'm usually exploring New York's food scene, cooking, running, traveling, or skiing in the winter."
   ],
   "experience": [

--- a/me/profile.json
+++ b/me/profile.json
@@ -3,7 +3,7 @@
   "role": "Senior Software Engineer",
   "location": "Brooklyn, New York",
   "bio": [
-    "I'm a senior software engineer based in Brooklyn. I work across the stack — React, TypeScript, and Next.js on the front end, Python and Node services behind them — and I care most about the unglamorous parts: clear boundaries between components, tests that catch real regressions, and code the next person can change without fear.",
+    "I'm a senior software engineer based in Brooklyn. I work across the stack — React, TypeScript, and Next.js on the front end, Python and Node services behind them. I care deeply about clean, maintainable code, collaborative problem-solving, and continuous learning.",
     "Most of my work has been in regulated and public-interest domains: government services at Nava, banking at Wells Fargo, and health research at Kaiser Permanente. In those settings reliability and accessibility aren't finishing touches, which has shaped how I approach everything else.",
     "Outside of work I'm usually exploring New York's food scene, cooking, running, traveling, or skiing in the winter."
   ],

--- a/me/profile.json
+++ b/me/profile.json
@@ -68,8 +68,7 @@
   ],
   "certifications": [
     {
-      "name": "AWS Certified Cloud Practitioner",
-      "issued": "May 2022"
+      "name": "AWS Certified Cloud Practitioner"
     }
   ],
   "skills": [

--- a/me/profile.json
+++ b/me/profile.json
@@ -1,0 +1,135 @@
+{
+  "name": "Ryan Lewis",
+  "role": "Senior Software Engineer",
+  "location": "Brooklyn, New York",
+  "bio": [
+    "I'm a senior software engineer based in Brooklyn. I work across the stack — React, TypeScript, and Next.js on the front end, Python and Node services behind them — and I care most about the unglamorous parts: clear boundaries between components, tests that catch real regressions, and code the next person can change without fear.",
+    "Most of my work has been in regulated and public-interest domains: government services at Nava, banking at Wells Fargo, and health research at Kaiser Permanente. In those settings reliability and accessibility aren't finishing touches, which has shaped how I approach everything else.",
+    "Outside of work I'm usually exploring New York's food scene, cooking, running, traveling, or skiing in the winter."
+  ],
+  "experience": [
+    {
+      "company": "Nava",
+      "title": "Sr Software Engineer",
+      "start": "Oct 2021",
+      "end": "Present"
+    },
+    {
+      "company": "Wells Fargo",
+      "title": "Software Engineer",
+      "start": "Dec 2017",
+      "end": "Aug 2021"
+    },
+    {
+      "company": "Children's Council of San Francisco",
+      "title": "Web Developer",
+      "start": "Mar 2016",
+      "end": "Dec 2017"
+    },
+    {
+      "company": "Kaiser Permanente Division of Research",
+      "title": "Web Developer",
+      "start": "Jul 2010",
+      "end": "Feb 2016"
+    }
+  ],
+  "education": [
+    {
+      "school": "Georgia Institute of Technology (OMSCS)",
+      "credential": "Master's degree in Computer Science",
+      "years": "2017-2018",
+      "detail": "4.0 GPA",
+      "coursework": [
+        "Information Security",
+        "Machine Learning for Trading",
+        "Software Development Process",
+        "Cyber Physical Systems",
+        "Machine Learning",
+        "Database Systems and Design",
+        "Education Technology",
+        "Human Computer Interaction",
+        "Intro to Health Informatics",
+        "Knowledge-Based AI"
+      ]
+    },
+    {
+      "school": "University of California, Santa Cruz",
+      "credential": "Computer Engineering",
+      "coursework": [
+        "Data Structures",
+        "Computer Architecture",
+        "Logic Design with Verilog",
+        "Microsystem Design",
+        "Operating Systems",
+        "Abstract Data Types",
+        "Mechatronics"
+      ]
+    }
+  ],
+  "certifications": [
+    {
+      "name": "AWS Certified Cloud Practitioner",
+      "issued": "May 2022"
+    }
+  ],
+  "skills": [
+    {
+      "group": "Frontend",
+      "items": [
+        "React",
+        "TypeScript",
+        "JavaScript",
+        "Next.js",
+        "Vue.js",
+        "Redux",
+        "GraphQL (Apollo Client)"
+      ]
+    },
+    {
+      "group": "Backend",
+      "items": ["Python", "Django", "Flask", "Node.js", "GraphQL"]
+    },
+    {
+      "group": "Databases",
+      "items": ["PostgreSQL", "SQL"]
+    },
+    {
+      "group": "Tools",
+      "items": [
+        "Docker",
+        "Git",
+        "Jest",
+        "React Testing Library",
+        "Playwright"
+      ]
+    },
+    {
+      "group": "Machine Learning",
+      "items": [
+        "Supervised learning",
+        "Unsupervised learning",
+        "Reinforcement learning"
+      ]
+    }
+  ],
+  "volunteering": [
+    {
+      "organization": "UBELONG in Laos",
+      "dates": "Sep-Oct 2013",
+      "description": "Training local staff in product marketing and teaching English at a local primary school"
+    }
+  ],
+  "interests": [
+    "Exploring New York's food scene",
+    "Cooking and experimenting in the kitchen",
+    "Running",
+    "Traveling",
+    "Skiing in the winter"
+  ],
+  "links": {
+    "linkedin": "https://www.linkedin.com/in/ryan-lewis-378657a/",
+    "github": "https://github.com/rylew2",
+    "email": "ryanlewis312@gmail.com",
+    "resume": null
+  }
+}

--- a/me/summary.txt
+++ b/me/summary.txt
@@ -2,7 +2,7 @@ Ryan Lewis is a Senior Software Engineer based in Brooklyn, New York.
 
 I'm a senior software engineer based in Brooklyn. I work across the stack — React, TypeScript, and Next.js on the front end, Python and Node services behind them. I care deeply about clean, maintainable code, collaborative problem-solving, and continuous learning.
 
-Most of my work has been in regulated and public-interest domains: government services at Nava, banking at Wells Fargo, and health research at Kaiser Permanente. In those settings reliability and accessibility aren't finishing touches, which has shaped how I approach everything else.
+Most of my work has been in regulated and public-interest domains: government services at Nava, banking at Wells Fargo, and health research at Kaiser Permanente.
 
 Outside of work I'm usually exploring New York's food scene, cooking, running, traveling, or skiing in the winter.
 

--- a/me/summary.txt
+++ b/me/summary.txt
@@ -1,4 +1,10 @@
-Ryan Lewis is a Senior Software Engineer based in Brooklyn, New York who enjoys tackling complex technical challenges and delivering reliable, user-centered software. He has a passion for continuous learning, a collaborative approach, and using technology to solve real-world problems.
+Ryan Lewis is a Senior Software Engineer based in Brooklyn, New York.
+
+I'm a senior software engineer based in Brooklyn. I work across the stack — React, TypeScript, and Next.js on the front end, Python and Node services behind them — and I care most about the unglamorous parts: clear boundaries between components, tests that catch real regressions, and code the next person can change without fear.
+
+Most of my work has been in regulated and public-interest domains: government services at Nava, banking at Wells Fargo, and health research at Kaiser Permanente. In those settings reliability and accessibility aren't finishing touches, which has shaped how I approach everything else.
+
+Outside of work I'm usually exploring New York's food scene, cooking, running, traveling, or skiing in the winter.
 
 WORK EXPERIENCE:
 - Nava - Sr Software Engineer (Oct 2021 - Present)
@@ -7,9 +13,9 @@ WORK EXPERIENCE:
 - Kaiser Permanente Division of Research - Web Developer (Jul 2010 - Feb 2016)
 
 EDUCATION:
-- Master's degree in Computer Science from Georgia Institute of Technology (OMSCS), 2017-2018, 4.0 GPA
+- Georgia Institute of Technology (OMSCS) — Master's degree in Computer Science, 2017-2018, 4.0 GPA
   Coursework: Information Security, Machine Learning for Trading, Software Development Process, Cyber Physical Systems, Machine Learning, Database Systems and Design, Education Technology, Human Computer Interaction, Intro to Health Informatics, Knowledge-Based AI
-- University of California, Santa Cruz - Computer Engineering
+- University of California, Santa Cruz — Computer Engineering
   Coursework: Data Structures, Computer Architecture, Logic Design with Verilog, Microsystem Design, Operating Systems, Abstract Data Types, Mechatronics
 
 CERTIFICATIONS:
@@ -19,19 +25,8 @@ TECHNICAL SKILLS:
 - Frontend: React, TypeScript, JavaScript, Next.js, Vue.js, Redux, GraphQL (Apollo Client)
 - Backend: Python, Django, Flask, Node.js, GraphQL
 - Databases: PostgreSQL, SQL
-- Tools: Docker, Git, Testing (Jest, React Testing Library, Playwright)
-- Machine Learning: Supervised learning, unsupervised learning, reinforcement learning
-
-NOTABLE PROJECTS:
-1. Card Game - A full-stack React/GraphQL/Django card game with TypeScript, Redux Toolkit, PostgreSQL, and Docker. Features include game state management, GraphQL mutations/queries, and comprehensive testing.
-
-2. SenseCourse - An EdTech application built for Georgia Tech's Educational Technology course. Uses IBM Watson for sentiment analysis to help OMSCS students choose courses based on personality matching with course reviews.
-
-3. GitHub Browser - A tool for exploring GitHub repositories and data.
-
-4. Machine Learning Projects - A series of projects covering supervised learning, randomized optimization, unsupervised learning, and reinforcement learning from the OMSCS curriculum.
-
-5. SharePoint CRA Starter - A starter template for building SharePoint applications with Create React App.
+- Tools: Docker, Git, Jest, React Testing Library, Playwright
+- Machine Learning: Supervised learning, Unsupervised learning, Reinforcement learning
 
 VOLUNTEERING:
 - UBELONG in Laos (Sep-Oct 2013) - Training local staff in product marketing and teaching English at a local primary school
@@ -44,6 +39,6 @@ INTERESTS OUTSIDE WORK:
 - Skiing in the winter
 
 CONTACT:
-- LinkedIn: linkedin.com/in/ryan-lewis-378657a/
-- GitHub: github.com/rylew2
+- LinkedIn: https://www.linkedin.com/in/ryan-lewis-378657a/
+- GitHub: https://github.com/rylew2
 - Email: ryanlewis312@gmail.com

--- a/me/summary.txt
+++ b/me/summary.txt
@@ -1,6 +1,6 @@
 Ryan Lewis is a Senior Software Engineer based in Brooklyn, New York.
 
-I'm a senior software engineer based in Brooklyn. I work across the stack — React, TypeScript, and Next.js on the front end, Python and Node services behind them — and I care most about the unglamorous parts: clear boundaries between components, tests that catch real regressions, and code the next person can change without fear.
+I'm a senior software engineer based in Brooklyn. I work across the stack — React, TypeScript, and Next.js on the front end, Python and Node services behind them. I care deeply about clean, maintainable code, collaborative problem-solving, and continuous learning.
 
 Most of my work has been in regulated and public-interest domains: government services at Nava, banking at Wells Fargo, and health research at Kaiser Permanente. In those settings reliability and accessibility aren't finishing touches, which has shaped how I approach everything else.
 

--- a/me/summary.txt
+++ b/me/summary.txt
@@ -19,7 +19,7 @@ EDUCATION:
   Coursework: Data Structures, Computer Architecture, Logic Design with Verilog, Microsystem Design, Operating Systems, Abstract Data Types, Mechatronics
 
 CERTIFICATIONS:
-- AWS Certified Cloud Practitioner (issued May 2022)
+- AWS Certified Cloud Practitioner
 
 TECHNICAL SKILLS:
 - Frontend: React, TypeScript, JavaScript, Next.js, Vue.js, Redux

--- a/me/summary.txt
+++ b/me/summary.txt
@@ -22,10 +22,10 @@ CERTIFICATIONS:
 - AWS Certified Cloud Practitioner (issued May 2022)
 
 TECHNICAL SKILLS:
-- Frontend: React, TypeScript, JavaScript, Next.js, Vue.js, Redux, GraphQL (Apollo Client)
+- Frontend: React, TypeScript, JavaScript, Next.js, Vue.js, Redux
 - Backend: Python, Django, Flask, Node.js, GraphQL
-- Databases: PostgreSQL, SQL
-- Tools: Docker, Git, Jest, React Testing Library, Playwright
+- Databases: PostgreSQL
+- Tools: Docker, Colima, Git, Jest, React Testing Library, Playwright
 - Machine Learning: Supervised learning, Unsupervised learning, Reinforcement learning
 
 VOLUNTEERING:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "generate:context": "tsx scripts/generate-chat-context.ts",
-    "prebuild": "npm run generate:context"
+    "generate:summary": "tsx scripts/generate-summary.ts",
+    "prebuild": "npm run generate:summary && npm run generate:context"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -48,6 +48,20 @@ const About = () => {
               {bio.map((paragraph) => (
                 <p key={paragraph.slice(0, 40)}>{paragraph}</p>
               ))}
+              {/* Contact details live in the footer. The résumé is the one link
+                  the footer doesn't carry, so it sits here instead. */}
+              {links.resume && (
+                <p>
+                  <a
+                    className="resumeLink"
+                    href={links.resume}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Résumé (PDF)
+                  </a>
+                </p>
+              )}
             </div>
           </div>
 
@@ -109,40 +123,6 @@ const About = () => {
                 </div>
               ))}
             </dl>
-          </section>
-
-          <section className="aboutSection">
-            <h2>Contact</h2>
-            <ul className="contactList">
-              {links.resume && (
-                <li>
-                  <a
-                    href={links.resume}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Résumé (PDF)
-                  </a>
-                </li>
-              )}
-              <li>
-                <a
-                  href={links.linkedin}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  LinkedIn
-                </a>
-              </li>
-              <li>
-                <a href={links.github} target="_blank" rel="noopener noreferrer">
-                  GitHub
-                </a>
-              </li>
-              <li>
-                <a href={`mailto:${links.email}`}>{links.email}</a>
-              </li>
-            </ul>
           </section>
         </Container>
       </StyledAbout>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -96,9 +96,11 @@ const About = () => {
               {certifications.map((certification) => (
                 <li key={certification.name}>
                   <span className="entryPrimary">{certification.name}</span>
-                  <span className="entrySecondary">
-                    Issued {certification.issued}
-                  </span>
+                  {certification.issued && (
+                    <span className="entrySecondary">
+                      Issued {certification.issued}
+                    </span>
+                  )}
                 </li>
               ))}
             </ul>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -2,44 +2,148 @@ import Image from 'next/image';
 import React from 'react';
 import { Container, Layout } from '../components';
 import { StyledAbout } from '../components/styles/about.styles';
+import { profile } from '../lib/profile';
 
 /**
  * About page `/about`
+ *
+ * Everything factual here comes from me/profile.json, which also generates the
+ * summary the chat assistant is given. Edit that file, not this one.
  */
 const About = () => {
+  const {
+    name,
+    role,
+    location,
+    bio,
+    experience,
+    education,
+    certifications,
+    skills,
+    links,
+  } = profile;
+
   return (
     <Layout
       pathname={'/about'}
       pageTitle="About"
-      pageDescription="About page of Ryan Lewis, NYC Developer"
+      pageDescription={`${role} based in ${location}. Experience, education, and the tools I build with.`}
     >
       <StyledAbout>
         <Container width="narrow">
-          <div className="postContent">
+          <div className="aboutIntro">
             <div className="avatarImage">
               <Image
                 src="/images/avatar2.png"
                 width={200}
                 height={200}
-                layout="fixed"
-                alt="Ryan Lewis"
+                alt={name}
+                priority
               />
             </div>
-
-            <p>
-              I’m a software engineer who enjoys tackling complex technical
-              challenges and delivering reliable, user-centered software. My
-              experience spans designing and building modern web applications,
-              architecting scalable back-end systems, and integrating with
-              various content and data platforms.
-            </p>
-            <p>
-              I care deeply about clean, maintainable code, collaborative
-              problem-solving, and continuous learning. Outside of work, I love
-              exploring New York’s endless food scene, experimenting in the
-              kitchen, running, traveling, and skiing in the winter.
-            </p>
+            <div className="introText">
+              <p className="positioning">
+                {role} · {location}
+              </p>
+              {bio.map((paragraph) => (
+                <p key={paragraph.slice(0, 40)}>{paragraph}</p>
+              ))}
+            </div>
           </div>
+
+          <section className="aboutSection">
+            <h2>Experience</h2>
+            <ol className="timeline">
+              {experience.map((job) => (
+                <li key={`${job.company}-${job.start}`}>
+                  <span className="entryPrimary">{job.company}</span>
+                  <span className="entrySecondary">{job.title}</span>
+                  <span className="entryMeta">
+                    {job.start} – {job.end}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <section className="aboutSection">
+            <h2>Education &amp; Certifications</h2>
+            <ul className="credentials">
+              {education.map((school) => (
+                <li key={school.school}>
+                  <span className="entryPrimary">{school.school}</span>
+                  <span className="entrySecondary">
+                    {[school.credential, school.years, school.detail]
+                      .filter(Boolean)
+                      .join(' · ')}
+                  </span>
+                </li>
+              ))}
+              {certifications.map((certification) => (
+                <li key={certification.name}>
+                  <span className="entryPrimary">{certification.name}</span>
+                  <span className="entrySecondary">
+                    Issued {certification.issued}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="aboutSection">
+            <h2>Skills</h2>
+            {/* A plain pill list rather than the Chips component: Chips links
+                each item to a relative `tags/` route, which would 404 from
+                /about and would pull every skill into config/tags.json. */}
+            <dl className="skillGroups">
+              {skills.map((group) => (
+                <div className="skillGroup" key={group.group}>
+                  <dt>{group.group}</dt>
+                  <dd>
+                    <ul className="skillPills">
+                      {group.items.map((item) => (
+                        <li key={item}>{item}</li>
+                      ))}
+                    </ul>
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+
+          <section className="aboutSection">
+            <h2>Contact</h2>
+            <ul className="contactList">
+              {links.resume && (
+                <li>
+                  <a
+                    href={links.resume}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Résumé (PDF)
+                  </a>
+                </li>
+              )}
+              <li>
+                <a
+                  href={links.linkedin}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  LinkedIn
+                </a>
+              </li>
+              <li>
+                <a href={links.github} target="_blank" rel="noopener noreferrer">
+                  GitHub
+                </a>
+              </li>
+              <li>
+                <a href={`mailto:${links.email}`}>{links.email}</a>
+              </li>
+            </ul>
+          </section>
         </Container>
       </StyledAbout>
     </Layout>

--- a/scripts/generate-summary.ts
+++ b/scripts/generate-summary.ts
@@ -1,0 +1,136 @@
+/**
+ * Generates me/summary.txt from me/profile.json.
+ *
+ * me/profile.json is the single source of truth for biographical facts. The
+ * About page imports it directly; the chat API reads the summary.txt emitted
+ * here (pages/api/chat.ts -> loadSummary) so the assistant can never contradict
+ * what the page shows.
+ *
+ * Deliberately no "generated file, do not edit" banner in the output: chat.ts
+ * interpolates summary.txt verbatim into the LLM system prompt, so any banner
+ * would become part of the prompt. Edit profile.json instead.
+ *
+ * Project descriptions are intentionally absent. The prompt already receives
+ * every project from me/chat-context.json in far more detail, generated from
+ * content/project/*.md.
+ */
+import fs from 'fs';
+import path from 'path';
+import type { Education, Profile } from '../lib/profile';
+
+const profilePath = path.join(process.cwd(), 'me', 'profile.json');
+const outputPath = path.join(process.cwd(), 'me', 'summary.txt');
+
+function formatEducation(entry: Education): string {
+  // School first, matching the company-first shape of the work experience
+  // lines. Credential is free text because not every entry is a named degree.
+  const headline = [
+    `- ${entry.school} — ${entry.credential}`,
+    entry.years,
+    entry.detail,
+  ]
+    .filter(Boolean)
+    .join(', ');
+
+  if (!entry.coursework?.length) {
+    return headline;
+  }
+
+  return `${headline}\n  Coursework: ${entry.coursework.join(', ')}`;
+}
+
+function buildSummary(profile: Profile): string {
+  const sections: string[] = [];
+
+  sections.push(
+    `${profile.name} is a ${profile.role} based in ${profile.location}.`,
+  );
+  sections.push(profile.bio.join('\n\n'));
+
+  sections.push(
+    [
+      'WORK EXPERIENCE:',
+      ...profile.experience.map(
+        (job) => `- ${job.company} - ${job.title} (${job.start} - ${job.end})`,
+      ),
+    ].join('\n'),
+  );
+
+  sections.push(
+    ['EDUCATION:', ...profile.education.map(formatEducation)].join('\n'),
+  );
+
+  if (profile.certifications.length) {
+    sections.push(
+      [
+        'CERTIFICATIONS:',
+        ...profile.certifications.map(
+          (cert) => `- ${cert.name} (issued ${cert.issued})`,
+        ),
+      ].join('\n'),
+    );
+  }
+
+  sections.push(
+    [
+      'TECHNICAL SKILLS:',
+      ...profile.skills.map(
+        (group) => `- ${group.group}: ${group.items.join(', ')}`,
+      ),
+    ].join('\n'),
+  );
+
+  if (profile.volunteering.length) {
+    sections.push(
+      [
+        'VOLUNTEERING:',
+        ...profile.volunteering.map(
+          (entry) =>
+            `- ${entry.organization} (${entry.dates}) - ${entry.description}`,
+        ),
+      ].join('\n'),
+    );
+  }
+
+  sections.push(
+    [
+      'INTERESTS OUTSIDE WORK:',
+      ...profile.interests.map((interest) => `- ${interest}`),
+    ].join('\n'),
+  );
+
+  const contact = [
+    'CONTACT:',
+    `- LinkedIn: ${profile.links.linkedin}`,
+    `- GitHub: ${profile.links.github}`,
+    `- Email: ${profile.links.email}`,
+  ];
+  if (profile.links.resume) {
+    contact.push(`- Resume: ${profile.links.resume}`);
+  }
+  sections.push(contact.join('\n'));
+
+  return `${sections.join('\n\n')}\n`;
+}
+
+function main() {
+  console.log('Generating profile summary...');
+
+  const profile = JSON.parse(
+    fs.readFileSync(profilePath, 'utf-8'),
+  ) as Profile;
+  const summary = buildSummary(profile);
+
+  fs.writeFileSync(outputPath, summary);
+
+  console.log(`Generated profile summary:`);
+  console.log(`  - ${profile.experience.length} roles`);
+  console.log(`  - ${profile.education.length} schools`);
+  console.log(
+    `  - ${profile.skills.reduce((total, group) => total + group.items.length, 0)} skills`,
+  );
+  console.log(`  - Total size: ${(summary.length / 1024).toFixed(2)} KB`);
+  console.log(`Output: ${outputPath}`);
+}
+
+main();

--- a/scripts/generate-summary.ts
+++ b/scripts/generate-summary.ts
@@ -43,7 +43,7 @@ function buildSummary(profile: Profile): string {
   const sections: string[] = [];
 
   sections.push(
-    `${profile.name} is a ${profile.role} based in ${profile.location}.`,
+    `${profile.name} is a ${profile.role} based in ${profile.location}.`
   );
   sections.push(profile.bio.join('\n\n'));
 
@@ -51,23 +51,25 @@ function buildSummary(profile: Profile): string {
     [
       'WORK EXPERIENCE:',
       ...profile.experience.map(
-        (job) => `- ${job.company} - ${job.title} (${job.start} - ${job.end})`,
+        (job) => `- ${job.company} - ${job.title} (${job.start} - ${job.end})`
       ),
-    ].join('\n'),
+    ].join('\n')
   );
 
   sections.push(
-    ['EDUCATION:', ...profile.education.map(formatEducation)].join('\n'),
+    ['EDUCATION:', ...profile.education.map(formatEducation)].join('\n')
   );
 
   if (profile.certifications.length) {
     sections.push(
       [
         'CERTIFICATIONS:',
-        ...profile.certifications.map(
-          (cert) => `- ${cert.name} (issued ${cert.issued})`,
+        ...profile.certifications.map((cert) =>
+          cert.issued
+            ? `- ${cert.name} (issued ${cert.issued})`
+            : `- ${cert.name}`
         ),
-      ].join('\n'),
+      ].join('\n')
     );
   }
 
@@ -75,9 +77,9 @@ function buildSummary(profile: Profile): string {
     [
       'TECHNICAL SKILLS:',
       ...profile.skills.map(
-        (group) => `- ${group.group}: ${group.items.join(', ')}`,
+        (group) => `- ${group.group}: ${group.items.join(', ')}`
       ),
-    ].join('\n'),
+    ].join('\n')
   );
 
   if (profile.volunteering.length) {
@@ -86,9 +88,9 @@ function buildSummary(profile: Profile): string {
         'VOLUNTEERING:',
         ...profile.volunteering.map(
           (entry) =>
-            `- ${entry.organization} (${entry.dates}) - ${entry.description}`,
+            `- ${entry.organization} (${entry.dates}) - ${entry.description}`
         ),
-      ].join('\n'),
+      ].join('\n')
     );
   }
 
@@ -96,7 +98,7 @@ function buildSummary(profile: Profile): string {
     [
       'INTERESTS OUTSIDE WORK:',
       ...profile.interests.map((interest) => `- ${interest}`),
-    ].join('\n'),
+    ].join('\n')
   );
 
   const contact = [
@@ -116,9 +118,7 @@ function buildSummary(profile: Profile): string {
 function main() {
   console.log('Generating profile summary...');
 
-  const profile = JSON.parse(
-    fs.readFileSync(profilePath, 'utf-8'),
-  ) as Profile;
+  const profile = JSON.parse(fs.readFileSync(profilePath, 'utf-8')) as Profile;
   const summary = buildSummary(profile);
 
   fs.writeFileSync(outputPath, summary);
@@ -127,7 +127,7 @@ function main() {
   console.log(`  - ${profile.experience.length} roles`);
   console.log(`  - ${profile.education.length} schools`);
   console.log(
-    `  - ${profile.skills.reduce((total, group) => total + group.items.length, 0)} skills`,
+    `  - ${profile.skills.reduce((total, group) => total + group.items.length, 0)} skills`
   );
   console.log(`  - Total size: ${(summary.length / 1024).toFixed(2)} KB`);
   console.log(`Output: ${outputPath}`);

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -38,9 +38,13 @@ test("about page lists education and certifications", async ({ page }) => {
     );
   }
   for (const certification of profile.certifications) {
-    await expect(entries.filter({ hasText: certification.name })).toContainText(
-      certification.issued
-    );
+    const entry = entries.filter({ hasText: certification.name });
+    await expect(entry).toHaveCount(1);
+
+    // The issued date is optional, so only assert it when one is configured.
+    if (certification.issued) {
+      await expect(entry).toContainText(certification.issued);
+    }
   }
 });
 

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -53,8 +53,8 @@ test("about page lists every skill in the profile", async ({ page }) => {
   for (const group of profile.skills) {
     await expect(skills.locator("dt", { hasText: group.group })).toBeVisible();
     for (const item of group.items) {
-      // Exact matching: "GraphQL" would otherwise also match the
-      // "GraphQL (Apollo Client)" pill and trip strict mode.
+      // Exact matching: "React" would otherwise also match the
+      // "React Testing Library" pill and trip strict mode.
       await expect(skills.getByText(item, { exact: true })).toBeVisible();
     }
   }

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "@playwright/test";
+import { profile } from "../lib/profile";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/about");
+});
+
+test("about page states role and location", async ({ page }) => {
+  await expect(
+    page.getByRole("heading", { name: `About ${profile.name}`, level: 1 })
+  ).toBeVisible();
+  await expect(
+    page.getByText(`${profile.role} · ${profile.location}`)
+  ).toBeVisible();
+});
+
+test("about page lists every role in the profile", async ({ page }) => {
+  const entries = page.locator("main .timeline li");
+  await expect(entries).toHaveCount(profile.experience.length);
+
+  for (const job of profile.experience) {
+    const entry = entries.filter({ hasText: job.company });
+    await expect(entry).toContainText(job.title);
+    await expect(entry).toContainText(job.start);
+    await expect(entry).toContainText(job.end);
+  }
+});
+
+test("about page lists education and certifications", async ({ page }) => {
+  const entries = page.locator("main .credentials li");
+  await expect(entries).toHaveCount(
+    profile.education.length + profile.certifications.length
+  );
+
+  for (const school of profile.education) {
+    await expect(entries.filter({ hasText: school.school })).toContainText(
+      school.credential
+    );
+  }
+  for (const certification of profile.certifications) {
+    await expect(entries.filter({ hasText: certification.name })).toContainText(
+      certification.issued
+    );
+  }
+});
+
+test("about page lists every skill in the profile", async ({ page }) => {
+  const skills = page.locator("main .skillGroups");
+  await expect(page.locator("main .skillGroup")).toHaveCount(
+    profile.skills.length
+  );
+
+  for (const group of profile.skills) {
+    await expect(skills.locator("dt", { hasText: group.group })).toBeVisible();
+    for (const item of group.items) {
+      // Exact matching: "GraphQL" would otherwise also match the
+      // "GraphQL (Apollo Client)" pill and trip strict mode.
+      await expect(skills.getByText(item, { exact: true })).toBeVisible();
+    }
+  }
+});
+
+test("about page links to contact channels", async ({ page }) => {
+  const contact = page.locator("main .contactList");
+
+  await expect(contact.getByRole("link", { name: "LinkedIn" })).toHaveAttribute(
+    "href",
+    profile.links.linkedin
+  );
+  await expect(contact.getByRole("link", { name: "GitHub" })).toHaveAttribute(
+    "href",
+    profile.links.github
+  );
+  await expect(
+    contact.getByRole("link", { name: profile.links.email })
+  ).toHaveAttribute("href", `mailto:${profile.links.email}`);
+});
+
+// Passes in both states: it asserts the résumé is absent while
+// links.resume is null, and asserts it actually serves a PDF once set.
+test("resume link matches the profile configuration", async ({
+  page,
+  request,
+}) => {
+  const navResume = page.locator("nav").getByRole("link", { name: "Resume" });
+  const aboutResume = page
+    .locator("main")
+    .getByRole("link", { name: "Résumé (PDF)" });
+
+  if (!profile.links.resume) {
+    await expect(navResume).toHaveCount(0);
+    await expect(aboutResume).toHaveCount(0);
+    return;
+  }
+
+  await expect(navResume).toHaveAttribute("href", profile.links.resume);
+  await expect(aboutResume).toHaveAttribute("href", profile.links.resume);
+
+  const response = await request.get(profile.links.resume);
+  expect(response.status()).toBe(200);
+  expect(response.headers()["content-type"]).toContain("pdf");
+});

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -60,20 +60,15 @@ test("about page lists every skill in the profile", async ({ page }) => {
   }
 });
 
-test("about page links to contact channels", async ({ page }) => {
-  const contact = page.locator("main .contactList");
+// Contact details are the footer's job, so the page body must not repeat them.
+test("about page leaves contact details to the footer", async ({ page }) => {
+  const main = page.locator("main");
 
-  await expect(contact.getByRole("link", { name: "LinkedIn" })).toHaveAttribute(
-    "href",
-    profile.links.linkedin
-  );
-  await expect(contact.getByRole("link", { name: "GitHub" })).toHaveAttribute(
-    "href",
-    profile.links.github
-  );
+  await expect(main.getByRole("link", { name: "LinkedIn" })).toHaveCount(0);
+  await expect(main.getByRole("link", { name: "GitHub" })).toHaveCount(0);
   await expect(
-    contact.getByRole("link", { name: profile.links.email })
-  ).toHaveAttribute("href", `mailto:${profile.links.email}`);
+    main.locator(`a[href="mailto:${profile.links.email}"]`)
+  ).toHaveCount(0);
 });
 
 // Passes in both states: it asserts the résumé is absent while

--- a/tests/content-pages.spec.ts
+++ b/tests/content-pages.spec.ts
@@ -48,8 +48,3 @@ test("home page lists selected works", async ({ page }) => {
     ).toBeVisible();
   }
 });
-
-test("about page renders", async ({ page }) => {
-  await page.goto("/about");
-  await expect(page.getByRole("heading", { name: "About Me" })).toBeVisible();
-});


### PR DESCRIPTION
Tier 1 items #1 and #2 from the portfolio audit, ahead of a job search.

## The problem

The site never said what I do for a living. The About page was two paragraphs of generic prose, while `me/summary.txt` — which has the role, the work history, OMSCS, the AWS cert, and the full skills list — was wired **only** into the chat API's system prompt. The chatbot knew the résumé; human visitors didn't.

## Approach

`me/profile.json` becomes the single source of truth:

```
me/profile.json  ──┬──▶  pages/about.tsx        (rendered at build)
  (hand-edited)    └──▶  me/summary.txt         (generated) ──▶ /api/chat system prompt
```

`scripts/generate-summary.ts` runs in `prebuild`, alongside the existing `generate:context`. The page and the assistant now can't contradict each other.

## Notes for review

- **No "generated file, do not edit" banner in `summary.txt`.** `chat.ts` interpolates it verbatim into the system prompt, so a banner would become part of the prompt. The warning lives in the script header and `lib/profile.ts` instead.
- **Skills don't reuse `<Chips>`.** Chips renders `<Link href={'tags/' + tag}>` — a *relative* href that resolves to `/about/tags/React` and 404s, and `tag-pages.spec.ts` would then require every skill to exist in `config/tags.json`. They're plain pills styled from the same `--chip-*` tokens.
- **`NOTABLE PROJECTS` is dropped from the generated summary.** The same prompt already receives every project in far more detail from `chat-context.json`, generated from `content/project/*.md`. Removing the hand-written copy removes a third place for project facts to drift.
- **The intro no longer floats the avatar.** `float` + `shape-outside` wrapped the new sections around the image too, so the intro is a flex row that stacks below the existing 759px breakpoint.
- **`<h1>` changed** from "About Me" to "About Ryan Lewis". The old assertion moved out of `content-pages.spec.ts` into the new `about-page.spec.ts`.

## Résumé: wired but inert

The nav entry and the About contact link both derive from `links.resume` in `profile.json`, which is currently `null`. **Nothing résumé-related renders yet** — by design, so the nav can't point at a 404.

To turn it on: drop the PDF at `public/Ryan-Lewis-Resume.pdf` and set `"resume": "/Ryan-Lewis-Resume.pdf"`. Both nav links (desktop and mobile share the array) and the About link appear together.

`about-page.spec.ts` covers both states: it asserts the résumé is **absent** while the field is null, and asserts the URL returns 200 with a PDF content-type once it's set. So adding the file is a verified change rather than a hope.

## Verification

- `npm run build` passes, including type-checking
- 9/9 tests in `about-page.spec.ts` + `content-pages.spec.ts`
- `accessibility.spec.ts` passes — axe clean on `/about` in **both** light and dark themes
- Rendered and eyeballed at 1280px and 390px, light and dark; heading order is h1 → h2 with no skips

## Not in scope

Tier 1 #3 (`config/index.json` title/description/keywords), #4 (homepage `<h1>`), and #5 (hardening `/api/chat`) are separate. The Nava gap — 4.5 years absent from the site — still needs a judgment call on what's publishable; the timeline here shows the role and dates without inventing detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
