### PR TITLE
Make the whole card clickable, not just the image

### DIFF
--- a/components/cards/cards.tsx
+++ b/components/cards/cards.tsx
@@ -17,19 +17,17 @@ const Cards = ({ data }: CardsProps) => {
     <StyledCards>
       {data.map((singleCard) => (
         <article className="article" key={singleCard.id}>
-          <Link
-            href={`/${singleCard.path}/[id]`}
-            as={`/${singleCard.path}/${singleCard.slug}`}
-            className="card-image"
-          >
+          {/* Decorative: the title link below names the destination, so alt
+              text here would just repeat it to a screen reader. */}
+          <div className="card-image">
             <Image
               src={singleCard.previewImage}
-              alt={singleCard.title ?? ''}
+              alt=""
               width={450}
               height={220}
               sizes="(min-width: 640px) 700px, 400px"
             />
-          </Link>
+          </div>
 
           <div className="card-body">
             {singleCard.liveSite ||
@@ -38,9 +36,12 @@ const Cards = ({ data }: CardsProps) => {
               ? getDemoLinks(singleCard)
               : getMetaRow(singleCard, isIndexPage)}
 
+            {/* Stretched via ::after to cover the whole card, so the padding
+                and description are clickable too. See cards.styles.ts. */}
             <Link
               href={`/${singleCard.path}/[id]`}
               as={`/${singleCard.path}/${singleCard.slug}`}
+              className="card-link"
             >
               <h2>{singleCard.title}</h2>
             </Link>
@@ -54,8 +55,6 @@ const Cards = ({ data }: CardsProps) => {
 };
 
 export { Cards };
-
-
 
 // Helper functions below to keep the jsx clean and readable
 

--- a/components/styles/cards.styles.ts
+++ b/components/styles/cards.styles.ts
@@ -14,6 +14,8 @@ export const StyledCards = styled.section`
   }
 
   article.article {
+    /* Bounds the .card-link overlay to this card. */
+    position: relative;
     display: flex;
     flex-direction: column;
     background: var(--surface);
@@ -32,6 +34,27 @@ export const StyledCards = styled.section`
     &:hover .card-image img {
       transform: scale(1.04);
     }
+
+    /* The hit area is the whole card, so the focus ring belongs on the card
+       rather than around the title text. Outline follows border-radius. */
+    &:has(.card-link:focus-visible) {
+      outline: 2px solid var(--prim-color);
+      outline-offset: 2px;
+    }
+  }
+
+  /* The title link stretches to cover the entire card, making the padding,
+     date and description clickable. The demo buttons opt back out below. */
+  .card-link::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+  }
+
+  /* Paired with the card-level ring above; without it both would show. */
+  .card-link:focus-visible {
+    outline: none;
   }
 
   .card-image {
@@ -63,6 +86,10 @@ export const StyledCards = styled.section`
   }
 
   .card-demo-link {
+    /* Sits above the stretched .card-link overlay so these external links stay
+       clickable instead of being swallowed by the card-wide hit area. */
+    position: relative;
+    z-index: 2;
     display: flex;
     align-items: center;
     gap: 0.3em;

--- a/tests/cards.spec.ts
+++ b/tests/cards.spec.ts
@@ -1,0 +1,80 @@
+import { test, expect, type Page } from '@playwright/test';
+import { getContentList } from '../lib/content';
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const cardFor = (page: Page, title: string) =>
+  page
+    .locator('main article')
+    .filter({ has: page.getByRole('heading', { name: title }) })
+    .first();
+
+test('clicking a card description opens the article', async ({ page }) => {
+  const project = getContentList('project').find(
+    (item) => item.slug && item.title && item.description
+  );
+
+  if (!project) {
+    throw new Error('No project has both a title and a description.');
+  }
+
+  await page.goto('/projects');
+
+  const card = cardFor(page, project.title!);
+  const description = card.locator('p').first();
+  await expect(description).toBeVisible();
+
+  // Click the description's coordinates rather than the element. The <p> is
+  // not a link and never receives the event -- the stretched overlay sits on
+  // top of it, which is exactly the behaviour under test. Locator.click()
+  // would fail its actionability check here for that reason.
+  const box = await description.boundingBox();
+  if (!box) {
+    throw new Error('The card description has no bounding box.');
+  }
+
+  await page.mouse.click(box.x + box.width / 2, box.y + box.height / 2);
+
+  await expect(page).toHaveURL(
+    new RegExp(`/projects/${escapeRegExp(project.slug!)}$`)
+  );
+});
+
+test('card action buttons stay clickable above the stretched link', async ({
+  page,
+}) => {
+  const project = getContentList('project').find(
+    (item) => item.sourceCode && item.title
+  );
+
+  if (!project) {
+    throw new Error('No project has a sourceCode link.');
+  }
+
+  await page.goto('/projects');
+
+  const source = cardFor(page, project.title!).getByRole('link', {
+    name: `${project.title} source code`,
+  });
+
+  await expect(source).toHaveAttribute('href', project.sourceCode!);
+
+  // A trial click runs Playwright's actionability checks without navigating.
+  // It fails if the card-wide overlay intercepts the pointer, which is the
+  // regression this guards against.
+  await source.click({ trial: true });
+});
+
+test('each card exposes a single link to its article', async ({ page }) => {
+  await page.goto('/projects');
+
+  const cards = page.locator('main article');
+  const count = await cards.count();
+  expect(count).toBeGreaterThan(0);
+
+  for (let index = 0; index < count; index += 1) {
+    const articleLinks = cards.nth(index).locator('a[href^="/projects/"]');
+    await expect(articleLinks).toHaveCount(1);
+  }
+});


### PR DESCRIPTION
## Problem

Cards lift on hover across their whole area, but only the preview image and the title were links. The date, description and padding were dead zones — the card looked clickable in places where it wasn't.

## Approach

The card contains real external links (Demo/Source/Presentation → GitHub, live sites), so wrapping `<article>` in an anchor was out — that nests anchors, which is invalid and breaks the inner links.

Instead the title link stretches across the card via an absolutely positioned `::after`, and the action buttons get a higher `z-index` to stay on top of it. Standard stretched-link pattern: it stays a real anchor, so cmd-click, middle-click and the status-bar URL preview all still work.

## Changes

- `article.article` gets `position: relative` to bound the overlay.
- `.card-link::after` covers the card at `z-index: 1`.
- `.card-demo-link` sits at `z-index: 2` so its links keep their own hit targets.
- The image is no longer a second link to the same article — each card now exposes **one** link instead of two, and its alt text became decorative so screen readers don't announce the title twice.
- The focus ring moves from the title text to the card, matching the new hit area.

A nice side effect: the existing `a:hover h2` rule now underlines the title when you hover anywhere on the card, reinforcing that the whole thing is one target. Hovering an action button correctly does not trigger it.

## Trade-off

The description text is no longer drag-selectable, since the overlay sits above it. Accepted as the cost of this approach.

## Testing

New `tests/cards.spec.ts` covers the three things that could regress: clicking the description navigates, the Source button stays clickable above the overlay, and each card exposes exactly one article link.

Full suite green — 18 passed, including the axe accessibility specs in light and dark mode. Production build succeeds.

Also verified in a browser that hit-testing the image, description and card padding all resolve to the card link while the action buttons resolve to themselves, and that keyboard focus draws the ring on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)