### PR TITLE
Fix the four blocking accessibility defects

### DIFF
--- a/components/cards/cards.tsx
+++ b/components/cards/cards.tsx
@@ -89,6 +89,10 @@ function getMetaLabel(singleCard: ContentListItem, isIndexPage: boolean) {
   );
 }
 
+// The actions are links, so they are anchors styled as buttons. Wrapping a
+// <button> in an <a> nests two controls: it gives every action a duplicate tab
+// stop, announces it twice, and collapses the anchor's own box to a 1px strip
+// that fails the 24x24 target-size minimum.
 function getDemoButtons(singleCard: ContentListItem) {
   return (
     <>
@@ -98,9 +102,9 @@ function getDemoButtons(singleCard: ContentListItem) {
           target="_blank"
           rel="noreferrer noopener"
           aria-label={`${singleCard.title} demo`}
-          className="a-demo"
+          className="card-action a-demo demo"
         >
-          <button className="demo">Demo</button>
+          Demo
         </a>
       )}
       {singleCard.sourceCode && (
@@ -109,9 +113,9 @@ function getDemoButtons(singleCard: ContentListItem) {
           target="_blank"
           rel="noreferrer noopener"
           aria-label={`${singleCard.title} source code`}
-          className="a-source"
+          className="card-action a-source source"
         >
-          <button className="source">Source</button>
+          Source
         </a>
       )}
       {singleCard.presentation && (
@@ -120,9 +124,9 @@ function getDemoButtons(singleCard: ContentListItem) {
           target="_blank"
           rel="noreferrer noopener"
           aria-label={`${singleCard.title} presentation`}
-          className="a-presentation"
+          className="card-action a-presentation presentation"
         >
-          <button className="presentation">Presentation</button>
+          Presentation
         </a>
       )}
     </>

--- a/components/chat/chat-widget.styles.ts
+++ b/components/chat/chat-widget.styles.ts
@@ -97,6 +97,10 @@ export const ChatHeader = styled.div`
     font-family: var(--font-manrope), 'Manrope', sans-serif;
     font-size: 1rem;
     font-weight: 700;
+    /* The global "h1..h6 { color: var(--text-color-black) }" rule in layout.css
+       otherwise wins over the white set on this header, leaving black on the
+       dark blue at 2.11:1. Inherit so the two can never drift apart again. */
+    color: inherit;
   }
 
   button {

--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -131,16 +131,20 @@ const Layout = ({
 
           <link rel="shortcut icon" href="/favicon.ico" />
         </Head>
+        <a className="skip-link" href="#main">
+          Skip to content
+        </a>
         <Nav />
-        {menuOpen ? (
-          <MobileNav />
-        ) : (
-          <>
-            <Header pathname={pathname} title={pageTitle} />
-            <StyledMain>{children}</StyledMain>
-            <Footer />
-          </>
-        )}
+        <Header pathname={pathname} title={pageTitle} />
+        {/* tabIndex lets the skip link actually move focus here, not just
+            scroll. main:focus drops the ring -- see layout.css. */}
+        <StyledMain id="main" tabIndex={-1}>
+          {children}
+        </StyledMain>
+        <Footer />
+        {/* Rendered last and positioned over the page rather than replacing
+            it, so the content above stays in the DOM while the menu is open. */}
+        {menuOpen && <MobileNav />}
         <ChatWidget />
       </MenuContext.Provider>
     </ThemeContext.Provider>

--- a/components/nav/mobile-nav.tsx
+++ b/components/nav/mobile-nav.tsx
@@ -1,35 +1,126 @@
 import Link from 'next/link';
-import React from 'react';
-import { StyledMobileNav } from '../styles/nav.styles';
+import React, { useContext, useEffect, useRef } from 'react';
+import { MenuContext } from '..';
+import { StyledHamburger, StyledMobileNav } from '../styles/nav.styles';
 import { navLinks as mobileNavLinks } from './nav';
 
+const FOCUSABLE = 'a[href], button:not([disabled])';
+
+/**
+ * Full-screen menu for narrow viewports.
+ *
+ * It renders *over* the page rather than in place of it. Swapping it for the
+ * page content used to unmount <main>, the <h1> and the footer, which left
+ * screen reader users with nothing to read and no landmark to return to.
+ *
+ * Because aria-modal hides everything behind the overlay from assistive tech,
+ * including the nav bar's hamburger, the menu carries its own close button.
+ */
 const MobileNav = () => {
+  const { toggleMenuOpen } = useContext(MenuContext);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const opener = document.activeElement as HTMLElement | null;
+    const { body } = document;
+    const previousOverflow = body.style.overflow;
+    body.style.overflow = 'hidden';
+
+    panelRef.current?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+
+    return () => {
+      body.style.overflow = previousOverflow;
+      opener?.focus();
+    };
+  }, []);
+
+  // The hamburger is display:none from 759px up, so crossing the breakpoint
+  // with the menu open would strand the overlay with no visible way out.
+  useEffect(() => {
+    const query = window.matchMedia('(min-width: 759px)');
+    const closeOnDesktop = () => {
+      if (query.matches) toggleMenuOpen();
+    };
+    query.addEventListener('change', closeOnDesktop);
+    return () => query.removeEventListener('change', closeOnDesktop);
+  }, [toggleMenuOpen]);
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      toggleMenuOpen();
+      return;
+    }
+
+    if (event.key !== 'Tab') return;
+
+    const focusable = Array.from(
+      panelRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE) ?? []
+    );
+    if (focusable.length === 0) return;
+
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
   return (
-    <StyledMobileNav>
-      <div className="mobile-nav-container">
-        <ul className="linkList">
-          {mobileNavLinks.map((item, idx) => {
-            return (
-              <li key={idx} className="listItem">
-                {item.link ? (
-                  <Link href={item.link} className="link">
-                    {item.title}
-                  </Link>
-                ) : (
-                  <a
-                    className="link"
-                    href={item.href}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    {item.title}
-                  </a>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      </div>
+    <StyledMobileNav
+      ref={panelRef}
+      id="mobile-menu"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Menu"
+      onKeyDown={handleKeyDown}
+    >
+      <nav aria-label="Site">
+        <div className="mobile-nav-bar">
+          <StyledHamburger
+            menuOpen
+            onClick={toggleMenuOpen}
+            aria-label="Close menu"
+            aria-expanded
+            aria-controls="mobile-menu"
+          />
+        </div>
+
+        <div className="mobile-nav-container">
+          <ul className="linkList">
+            {mobileNavLinks.map((item, idx) => {
+              return (
+                <li key={idx} className="listItem">
+                  {item.link ? (
+                    <Link
+                      href={item.link}
+                      className="link"
+                      onClick={toggleMenuOpen}
+                    >
+                      {item.title}
+                    </Link>
+                  ) : (
+                    <a
+                      className="link"
+                      href={item.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      onClick={toggleMenuOpen}
+                    >
+                      {item.title}
+                    </a>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </nav>
     </StyledMobileNav>
   );
 };

--- a/components/nav/nav.tsx
+++ b/components/nav/nav.tsx
@@ -89,6 +89,7 @@ const Nav = () => {
               onClick={toggleMenuOpen}
               aria-label={menuOpen ? 'Close menu' : 'Open menu'}
               aria-expanded={menuOpen}
+              aria-controls="mobile-menu"
             ></StyledHamburger>
           </div>
         </nav>

--- a/components/styles/cards.styles.ts
+++ b/components/styles/cards.styles.ts
@@ -99,24 +99,40 @@ export const StyledCards = styled.section`
       margin-right: auto;
     }
 
-    button {
+    /* Anchors styled as buttons, not anchors wrapping buttons -- see the note
+       in cards.tsx. min-height keeps the hit area at the 24px target-size
+       minimum now that the anchor is the control rather than a collapsed
+       inline box around one. */
+    a.card-action {
+      display: inline-flex;
+      align-items: center;
+      min-height: 24px;
       background: var(--button-bg);
       border: 1px solid var(--border-color);
       border-radius: 5px;
       padding: 4px 10px;
+      font-size: 0.8em;
       font-weight: bold;
+      line-height: 1.2;
       color: var(--button-text);
+      text-decoration: none;
+
       &:hover {
         background: var(--button-bg-hover);
         cursor: pointer;
         color: var(--button-text-hover);
+      }
+
+      &:focus-visible {
+        outline: 2px solid var(--prim-color);
+        outline-offset: 2px;
       }
     }
 
     /* Each action carries its own colour so a row of cards can be scanned for
        "has a live demo" without reading the labels. Hover fills with the
        darker -text shade rather than the border hue, which would fail AA. */
-    button.demo {
+    a.demo {
       background: var(--action-demo-bg);
       border-color: var(--action-demo-border);
       color: var(--action-demo-text);
@@ -127,7 +143,7 @@ export const StyledCards = styled.section`
       }
     }
 
-    button.source {
+    a.source {
       background: var(--action-source-bg);
       border-color: var(--action-source-border);
       color: var(--action-source-text);
@@ -138,7 +154,7 @@ export const StyledCards = styled.section`
       }
     }
 
-    button.presentation {
+    a.presentation {
       background: var(--action-presentation-bg);
       border-color: var(--action-presentation-border);
       color: var(--action-presentation-text);

--- a/components/styles/layout.css
+++ b/components/styles/layout.css
@@ -227,6 +227,36 @@ body {
   border: 0;
 }
 
+/* SKIP LINK
+   Off-screen until focused, then pinned above the nav (z-index 10) and the
+   chat widget (1000). The mobile menu overlay (1001) traps focus, so the skip
+   link is unreachable while that is open and does not need to clear it. */
+.skip-link {
+  position: fixed;
+  top: -4rem;
+  left: 0.5rem;
+  z-index: 1100;
+  padding: 0.6rem 1rem;
+  background: var(--surface);
+  color: var(--prim-color);
+  border: 1px solid var(--prim-color);
+  border-radius: 5px;
+  font-weight: bold;
+  transition: none;
+}
+
+.skip-link:focus {
+  top: 0.5rem;
+  outline: 2px solid var(--prim-color);
+  outline-offset: 2px;
+}
+
+/* main carries tabindex="-1" purely as the skip link's target, so it should
+   not draw a ring around the whole page when focus lands on it. */
+main:focus {
+  outline: none;
+}
+
 .page-intro {
   text-align: center;
   max-width: 500px;

--- a/components/styles/nav.styles.ts
+++ b/components/styles/nav.styles.ts
@@ -210,20 +210,29 @@ export const NavSection = styled.header`
   }
 `;
 
-export const StyledMobileNav = styled.section`
+/* Sits above the chat widget (z-index 1000) so a modal menu covers the whole
+   page, not most of it. */
+export const StyledMobileNav = styled.div`
   background: var(--page-bg);
-  position: absolute;
-  top: 0;
-  bottom: 0;
-  left: 0;
-  right: 0;
+  position: fixed;
+  inset: 0;
+  z-index: 1001;
+  overflow-y: auto;
   animation: ${fadeDown} 0.35s cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Lines the close button up with the hamburger it replaces: the nav bar's
+     1em padding plus the Container's 4% gutter. */
+  .mobile-nav-bar {
+    display: flex;
+    justify-content: flex-end;
+    padding: 1em 4%;
+  }
 
   .mobile-nav-container {
     display: flex;
     align-items: center;
     justify-content: center;
-    min-height: 100%;
+    min-height: calc(100vh - 5em);
   }
 
   .linkList {

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -27,6 +27,20 @@ const buildPageList = (): PageEntry[] => {
   ];
 };
 
+const WCAG_TAGS = [
+  "wcag2a",
+  "wcag2aa",
+  "wcag21a",
+  "wcag21aa",
+  "wcag22aa",
+  "best-practice",
+];
+
+const VIEWPORTS = [
+  { label: "desktop", width: 1280, height: 900 },
+  { label: "mobile", width: 390, height: 844 },
+];
+
 const reportViolations = (violations: Result[]) =>
   violations.map((violation) => {
     const targets = violation.nodes
@@ -35,41 +49,133 @@ const reportViolations = (violations: Result[]) =>
     return `${violation.id} (${violation.impact}) ${violation.help}\n${targets}`;
   });
 
+// Every scan below covers the whole document. Scoping to main used to hide the
+// nav, the footer, the chat widget, the mobile menu and even the <h1>, which
+// sits in a section above main -- the suite passed while all of those had
+// violations.
 test.describe("accessibility", () => {
-  test.describe.configure({ timeout: 120_000 });
+  test.describe.configure({ timeout: 300_000 });
   const pages = buildPageList();
 
-  test("light mode", async ({ page }) => {
-    test.setTimeout(120_000);
-    for (const { name, url } of pages) {
-      await page.goto(url);
-      await page.waitForLoadState("networkidle");
-      await expect(page.locator("main")).toBeVisible();
-      await expect(page.locator("html")).toHaveAttribute("data-theme", "light");
+  for (const theme of ["light", "dark"] as const) {
+    for (const viewport of VIEWPORTS) {
+      test(`${theme} mode, ${viewport.label}`, async ({ page }) => {
+        test.setTimeout(300_000);
 
-      const results = await new AxeBuilder({ page })
-        .include("main")
-        .analyze();
-      expect(reportViolations(results.violations), `a11y issues on ${name}`).toEqual([]);
+        await page.addInitScript((value: string) => {
+          window.localStorage.setItem("theme", value);
+        }, theme);
+        await page.setViewportSize({
+          width: viewport.width,
+          height: viewport.height,
+        });
+
+        for (const { name, url } of pages) {
+          await page.goto(url);
+          await page.waitForLoadState("networkidle");
+          await expect(page.locator("main")).toBeVisible();
+          await expect(page.locator("html")).toHaveAttribute("data-theme", theme);
+
+          const results = await new AxeBuilder({ page })
+            .withTags(WCAG_TAGS)
+            .analyze();
+          expect(
+            reportViolations(results.violations),
+            `a11y issues on ${name} (${theme}, ${viewport.label})`
+          ).toEqual([]);
+        }
+      });
     }
+  }
+
+  test("skip link is the first tab stop and moves focus to main", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    await page.keyboard.press("Tab");
+    const skipLink = page.locator(".skip-link");
+    await expect(skipLink).toBeFocused();
+    await expect(skipLink).toBeInViewport();
+
+    await page.keyboard.press("Enter");
+    await expect(page.locator("main")).toBeFocused();
   });
 
-  test("dark mode", async ({ page }) => {
-    test.setTimeout(120_000);
-    await page.addInitScript(() => {
-      window.localStorage.setItem("theme", "dark");
-    });
+  test("each card action is a single control, not a link wrapping a button", async ({
+    page,
+  }) => {
+    await page.goto("/projects");
+    await page.waitForLoadState("networkidle");
 
-    for (const { name, url } of pages) {
-      await page.goto(url);
+    // Nesting the two gave every action a duplicate tab stop and collapsed the
+    // anchor's box below the 24x24 target-size minimum.
+    await expect(page.locator("main a button, main button a")).toHaveCount(0);
+
+    const action = page.locator("main a.card-action").first();
+    const box = await action.boundingBox();
+    expect(box?.width ?? 0).toBeGreaterThanOrEqual(24);
+    expect(box?.height ?? 0).toBeGreaterThanOrEqual(24);
+  });
+
+  test("mobile menu overlays the page and returns focus on close", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    const hamburger = page.getByRole("button", { name: "Open menu" });
+    await hamburger.click();
+
+    const menu = page.getByRole("dialog", { name: "Menu" });
+    await expect(menu).toBeVisible();
+
+    // The page used to be unmounted while the menu was open, leaving screen
+    // reader users with no content and no landmark to return to.
+    await expect(page.locator("main")).toBeAttached();
+    await expect(page.locator("footer")).toBeAttached();
+    await expect(page.locator("h1")).toBeAttached();
+
+    // Focus starts inside the overlay and cannot escape it.
+    await expect(menu.getByRole("button", { name: "Close menu" })).toBeFocused();
+    for (let i = 0; i < 8; i += 1) {
+      await page.keyboard.press("Tab");
+      expect(
+        await page.evaluate(
+          () => !!document.activeElement?.closest("#mobile-menu")
+        ),
+        `focus escaped the menu after ${i + 1} tabs`
+      ).toBe(true);
+    }
+
+    await page.keyboard.press("Escape");
+    await expect(menu).toBeHidden();
+    await expect(hamburger).toBeFocused();
+  });
+
+  test("chat panel header meets contrast in both themes", async ({ page }) => {
+    for (const theme of ["light", "dark"] as const) {
+      await page.addInitScript((value: string) => {
+        window.localStorage.setItem("theme", value);
+      }, theme);
+      await page.goto("/");
       await page.waitForLoadState("networkidle");
-      await expect(page.locator("main")).toBeVisible();
-      await expect(page.locator("html")).toHaveAttribute("data-theme", "dark");
 
+      await page.getByRole("button", { name: "Open chat" }).click();
+      await expect(page.getByRole("heading", { name: "Chat with Ryan" })).toBeVisible();
+
+      // Scoped to contrast: the panel's dialog semantics are tracked
+      // separately, so a full scan of the open panel would fail for
+      // unrelated reasons.
       const results = await new AxeBuilder({ page })
-        .include("main")
+        .withRules(["color-contrast"])
         .analyze();
-      expect(reportViolations(results.violations), `a11y issues on ${name} (dark mode)`).toEqual([]);
+      expect(
+        reportViolations(results.violations),
+        `chat contrast (${theme})`
+      ).toEqual([]);
     }
   });
 });


### PR DESCRIPTION
Fixes the blocking items from an accessibility audit of the site. Everything here is WCAG 2.1/2.2 AA.

## How the issues were found

axe-core via `@axe-core/playwright` over the **whole document** — 6 pages × {light, dark} × {1280×900, 390×844}, plus the mobile menu and the chat panel open. 21 scans, **131 violation instances**. Manual keyboard and DOM probes caught three more that axe structurally cannot see.

**After: 0 violations**, except three `region` instances while the chat panel is open — those belong with the chat dialog-semantics work, which is deliberately not in this PR.

## What changed

### 1. Card actions were `<a>` wrapping `<button>`

```diff
-<a href={…} aria-label={`${title} demo`} className="a-demo">
-  <button className="demo">Demo</button>
-</a>
+<a href={…} aria-label={`${title} demo`} className="card-action a-demo demo">
+  Demo
+</a>
```

Two nested controls for one action. The accessibility tree showed `link "Card Game source code" > button "Source"`, and the tab order gave each action two stops:

```
10. a.a-demo    [Card Game demo]     11. button.demo   "Demo"
12. a.a-source  [Card Game source]   13. button.source "Source"
```

It was also the sole cause of all **126** `target-size` failures — the inline anchor collapsed around the button, leaving a 1px-tall strip. The styles move from `button.demo` to `a.demo`, with `min-height: 24px` so the anchor itself clears the target-size minimum. Rendering is unchanged.

### 2. Opening the mobile menu deleted the page

`Layout` rendered `MobileNav` *instead of* the content. Probed at 390px with the menu open: `mainPresent: false, footerPresent: false, h1Present: false`. Escape did nothing.

It is now an overlay rendered alongside the page, with `role="dialog" aria-modal="true"`, its own close button (aria-modal hides the nav bar's hamburger from assistive tech), a focus trap, Escape to close, focus restored to the hamburger, and a body scroll lock. It also auto-closes when the viewport crosses 759px, where the hamburger is `display: none` — otherwise resizing would strand the overlay with no visible way out.

After: `mainPresent: true, footerPresent: true, h1Present: true, bodyOverflow: hidden, focus: "Close menu"` → Escape → `dialogGone: true, focus: "Open menu", bodyOverflow: visible`.

### 3. Chat panel title at 2.11:1 in light mode

The global `h1..h6 { color: var(--text-color-black) }` in `layout.css` beat the `color: white` on `ChatHeader`, so the title rendered `#000` on `#154475`. Fixed with `color: inherit` on the `h3`, so the two can't drift apart again. Dark mode was already fine.

### 4. Skip link

Every page had seven tab stops — logo, five nav links, theme toggle — before the first content. `main` gets `id="main"` and `tabindex="-1"` so the link moves focus rather than only scrolling.

Tab order on `/projects` now:

```
1. a.skip-link "Skip to content"   …   9. a.card-action "Card Game demo"
                                      10. a.card-action "Card Game source code"
                                      11. a.card-link   "Card Game"
```

### 5. The a11y suite couldn't see any of this

`tests/accessibility.spec.ts` scoped axe with `.include("main")`, which excluded the nav, footer, chat widget, mobile menu **and the `h1`** (it lives in a `section` above `main`). The suite was green the whole time.

It now scans the full document across both themes *and* both viewports, and adds four regression tests: skip link focus, one control per card action at ≥24×24, the mobile menu overlay + focus trap + focus restoration, and chat header contrast in both themes.

## Verification

- `npx playwright test` — 24/24 pass
- `npm run build` — exit 0
- `npx tsc --noEmit` — no new errors (6 pre-existing `implicitly has an 'any' type` errors remain in `content-pages.spec.ts` / `tag-pages.spec.ts`, untouched here)
- Screenshots checked in light and dark: card actions, mobile overlay, chat header, focused skip link — all render as before

## Deliberately not in this PR

From the same audit, left for follow-ups: chat panel dialog semantics (no `role="dialog"`, no focus trap, no Escape, input labelled only by its placeholder, replies not in a live region), placeholder alt text (`"logo"`, `"bookimage"`, `"projectimage"`), no `prefers-reduced-motion` support anywhere, a consistent `:focus-visible` token, and new-tab indication on the 13 `target="_blank"` links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
