### PR TITLE
Rewrite the Card Game case study

### DIFF
--- a/content/project/card-game.md
+++ b/content/project/card-game.md
@@ -20,13 +20,13 @@ tags:
 
 I built this card game to learn a new full-stack combination: React, Redux Toolkit, GraphQL, Django, and PostgreSQL. The game deals from a standard 52-card deck; the player wins by reaching the final hand with at least one ace and loses when all aces have been exhausted before then.
 
-The public demo is the standalone frontend. The Django, GraphQL, and PostgreSQL integration ran locally; the [source repository](https://github.com/rylew2/cardgame) contains both implementations.
+The public demo is the standalone frontend. The [source repository](https://github.com/rylew2/cardgame) contains the React frontend configured for local integration and the Django/GraphQL backend; the full path, including PostgreSQL, ran locally.
 
 ## Problem and constraints
 
 The interface needed to make the game state legible while preserving the card-game rules: it displays the current hand, cards remaining, aces remaining, and controls to deal, reset, or play again. Each deal replaces the hand with cards from the remaining deck, so the state must consistently track the deck, hand, counters, and game phase.
 
-I began with in-memory frontend state, then connected the same gameplay to a local backend. Keeping the deployed demo frontend-only was a deliberate delivery boundary: the public experience remains playable without presenting the local service integration as a hosted full-stack application.
+I began with in-memory frontend state, then connected the same gameplay to a local backend. The backend integration was not deployed: the public URL hosts only the standalone frontend, while the integrated path was exercised locally.
 
 ## Architecture and key decisions
 
@@ -47,10 +47,8 @@ That reducer update keeps the frontend's visible counters aligned with the cards
 
 The frontend test suite uses React Testing Library with a Redux-aware render helper. It covers the initial hand, distinct dealt hands, reset and play-again flows, and won and lost game states. The repository also includes Django service and GraphQL tests for dealing and resetting games.
 
-The public link in this project is the standalone React frontend. The full Django/GraphQL/PostgreSQL path was run locally, with the frontend configured to call the local GraphQL endpoint for that integration.
-
 ## Outcome and tradeoffs
 
-This project provided a concrete way to work through frontend state management, GraphQL types and operations, Django models and services, and a PostgreSQL-backed game state in one small application.
+The result was a playable public frontend, a locally exercised React/Django/GraphQL/PostgreSQL path, and automated coverage of frontend game states, backend services, and GraphQL mutations. Visitors to the public demo can play the in-memory frontend, but they cannot exercise the backend integration.
 
-The standalone frontend and the local full-stack integration intentionally remain separate delivery modes. Redux continues to represent the client-side game state even when the GraphQL-backed version is used, which kept the learning focus on both state-management approaches rather than reducing the application to only one of them.
+The integrated version keeps Redux client state alongside the persisted backend state. That duplicates some state across the client and server, while exposing both state-management approaches within the same project.

--- a/content/project/card-game.md
+++ b/content/project/card-game.md
@@ -16,268 +16,41 @@ tags:
   - postgres
 ---
 
-## Intro
+## Overview
 
-In this project, I was interested in working with a new stack, so I took on a project to build a card game with React, GraphQL, Django, and Postgres. This project was a foray into developing the frontend, establishing GraphQL model types, configuring a Django application, and setting up a PostgreSQL database, all containerized with Docker and orchestrated by robust Makefile commands. The project was my first time using Django, GraphQL, and `react-redux`.
+I built this card game to learn a new full-stack combination: React, Redux Toolkit, GraphQL, Django, and PostgreSQL. The game deals from a standard 52-card deck; the player wins by reaching the final hand with at least one ace and loses when all aces have been exhausted before then.
 
-[Source code here](https://github.com/rylew2/cardgame) - (full repo available by request)
+The public demo is the standalone frontend. The Django, GraphQL, and PostgreSQL integration ran locally; the [source repository](https://github.com/rylew2/cardgame) contains both implementations.
 
-## Game Rules
+## Problem and constraints
 
-- Standard 52-card deck
-- The goal is to end up with the last hand having at least one ace.
-- A dealt hand is 5 cards, and each hand is randomly dealt from the remaining cards in the deck each time the user clicks the `Deal` button.
-  - If you successfully make it to the final hand without losing, there will be 2 cards in the hand.
-- The game is "over" if all the aces in the deck have been dealt/exhausted before the last hand.
-- The game is considered a "win" if the last hand contains at least 1 ace.
-- The game can be replayed as many times as needed—there's always a Reset (or `Play Again`) button present.
-- The number of cards left and the number of aces left are displayed at the top.
+The interface needed to make the game state legible while preserving the card-game rules: it displays the current hand, cards remaining, aces remaining, and controls to deal, reset, or play again. Each deal replaces the hand with cards from the remaining deck, so the state must consistently track the deck, hand, counters, and game phase.
 
-## Frontend App
+I began with in-memory frontend state, then connected the same gameplay to a local backend. Keeping the deployed demo frontend-only was a deliberate delivery boundary: the public experience remains playable without presenting the local service integration as a hosted full-stack application.
 
-I first built the frontend app (without any GraphQL) with all the state (deck, hand, aces left) as in-memory data. The time-consuming part here was setting up all the CSS—especially for intricate pieces like the card suit (club/ace/heart/diamond in different orientations), the card animation and rotation, and the overall layout.
+## Architecture and key decisions
 
-The standalone frontend app is here:
-https://card-game-frontend.vercel.app/
+On the frontend, Redux Toolkit centralizes the deck, hand, remaining-card and ace counts, and game phase. The `deal` and `reset` reducers make game transitions explicit, while the components render the phase-specific controls and game state. The frontend also includes GraphQL operations and generated TypeScript types for the integrated version.
 
-### CSS/Design
+The local backend uses Django models for cards and games, a GraphQL schema with deal and reset mutations, and PostgreSQL for persistence. A card records its suit, rank, and status; a game records its phase. The service layer applies state changes through the Django ORM and uses `bulk_update` for card updates rather than saving each card inside a loop.
 
-To expedite development without perfecting the design, I utilized inline Tailwind utility classes. I'm typically used to a more established design system setup with larger projects, but I found simplifying CSS in this area got me to more of the frontend state management issues faster.
-
-Similarly, with the animation and rotation—I quickly gave a bit of a curve to make the hand look like it was dealt, added some opacity animations as cards were "dealt" into place on the board, and added confetti animation (3rd party package) for the win state.
-
-### React/state considerations
-
-Although `useState` is often sufficient for small apps, I opted to gain experience with `redux-toolkit`—so I spent some time reading their [excellent docs](https://redux-toolkit.js.org/tutorials/typescript) to help bootstrap the setup of TypeScript-friendly action creators and a test setup file that made it easy to mock the Redux store so I could test any game state easily.
-
-The store itself was fairly straightforward with 2 actions (`deal` and `reset`) and 2 reducers with the same names. The `Reset` action simply returns the deck to 47 cards (with 5 having been randomly dealt to the user). `Deal` will try to deal a new hand and determine what state that new hand will confer.
-
-The store's `deal` reducer:
-
-```js
-// filepath: src/store/gameSlice.ts
-// ...existing code...
-deal: (state: GameState, action: PayloadAction<DealAction>) => {
-    const { hand, deck } = action.payload;
-
-    const acesInHand = getAcesInHand(hand); // call to utility function
-    const stateAcesLeftInDeck = state.acesLeft - acesInHand;
-
-    // directly update state variables in an immutable way using redux-toolkit/Immer
-    state.deck = deck;
-    state.hand = hand;
-    state.cardsLeft = deck.length;
-    state.acesLeft -= acesInHand;
-
-    // check for game phase change if no aces left
-    if (stateAcesLeftInDeck <= 0) {
-        // if aces in hand on the last deal
-        if (acesInHand >= 1 && deck.length === 0) {
-            state.gamePhase = GamePhase.Won;
-        } else {
-            state.gamePhase = GamePhase.Lost;
-        }
-    }
-},
-// ...existing code...
+```ts
+state.deck = deck;
+state.hand = hand;
+state.cardsLeft = deck.length;
+state.acesLeft -= acesInHand;
 ```
 
-### Testing
+That reducer update keeps the frontend's visible counters aligned with the cards and hand returned by a deal.
 
-Once the Redux store `renderWithProviders` is set up, it becomes really easy to make assertions (using `React Testing Library`) for what's directly on the screen in a given state:
+## Testing and delivery
 
-```js
-// filepath: src/tests/game.test.ts
-// ...existing code...
-test('overridden initial state', () => {
-  const preloadedState = {
-    game: {
-      deck: [],
-      hand: [],
-      cardsLeft: 30,
-      acesLeft: 1,
-      gamePhase: GamePhase.InProgress,
-    },
-  };
+The frontend test suite uses React Testing Library with a Redux-aware render helper. It covers the initial hand, distinct dealt hands, reset and play-again flows, and won and lost game states. The repository also includes Django service and GraphQL tests for dealing and resetting games.
 
-  renderWithProviders(<App />, {
-    preloadedState,
-  });
+The public link in this project is the standalone React frontend. The full Django/GraphQL/PostgreSQL path was run locally, with the frontend configured to call the local GraphQL endpoint for that integration.
 
-  expect(screen.getByText('30')).toBeInTheDocument();
-  // additional assertions...
-});
-// ...existing code...
-```
+## Outcome and tradeoffs
 
-Or even a simple test that actually clicks things on the screen (I usually define button clicks and actions as their own functions to keep tests compact):
+This project provided a concrete way to work through frontend state management, GraphQL types and operations, Django models and services, and a PostgreSQL-backed game state in one small application.
 
-```js
-// filepath: src/tests/game.test.ts
-// ...existing code...
-test('reset game', async () => {
-  renderWithProviders(<App />);
-
-  expect(getCardsLeftCountByText('Cards Left')).toBe(47);
-  await waitFor(() => {
-    clickDealButton();
-    expect(getCardsLeftCountByText('Cards Left')).toBe(42);
-  });
-});
-// ...existing code...
-```
-
-### If more time allowed for the front end:
-
-While I wanted to touch all parts of the stack with this project and not spend a ton of time perfecting the frontend, there are a few areas I wish I had more time to explore:
-
-- Move some of the Tailwind inline classes into CSS files, maybe create app-specific variables for colors and shared styles. As mentioned above, the utility classes were done hastily to reach frontend completion.
-- Animation changes:
-  - Fix some of the animation jitter between each hand deal.
-  - There's also a known issue when going from a low viewport width to a high width—it will trigger the animation again. This could likely be stopped with a handleResize-type function preventing repeat animations.
-- I didn't get into any React performance issues with the React Dev tools given this was a small app—but you could look at things like `React.memo` or preventing unnecessary re-renders.
-  - I added some simple `useCallback` on the click handler functions that get passed down into other components.
-- More robust component library:
-  - Creating a reusable `Button` component, for example.
-  - Combining the game state components into one shared component (combining `GameWon`, `GameInProgress`, `GameLost`).
-- Pull test helper functions out to a separate file.
-- Exposing `graphqlService` as a hook instead of a service.
-
-## Backend
-
-### Backend overview
-
-- `card` table - stores all 52 cards for a deck.
-  - Multiple games could be played with just the 52 cards by resetting status or inserting 52 new entries tied to a new game ID. (I chose the former, but the latter is possible if you wanted to view a prior game's state.)
-- `game` table - simply stores the current status.
-- Mutations => `dealCards(count)`, `resetGame`.
-- Queries => returns `cardsLeftInDeck`, `acesLeftInDeck`, `gameStatus`.
-- The game likely could have been done all in memory—kind of how the standalone frontend works. Obviously, this wouldn't be durable or support multiple game/streak feature additions.
-
-The backend work included setting up a DB schema that had a `card` table that stores all 52 cards for a deck, with each card having a suit and rank, and a particular status (`Deck`, `Hand`, or `Discarded`). There's also a simple `game` table that simply stores the game phase (`In Progress`, `Won`, `Lost`, `Loading`)—this allows multiple games to be stored. Along with the standard Django tables, this was all that was needed to represent this game on the backend.
-
-For 3rd normal form, I considered introducing a lookup table for card statuses—this would put the status in one place, so it would be easy to rename a status in the future. However, I skipped this normalization step.
-
-Most of the database update functionality was placed in a `GameQueryService`—a quick collection of static methods that use the Django ORM for querying and updates. A potentially more idiomatic approach would be to embed this logic directly in the models, but I preferred the clean separation and development speed of a dedicated service layer.
-
-I did try to ensure that we weren't doing any database saves in loops, but rather running Django ORM's `bulk_update` after all data updates were made. Although we're dealing with a small amount of data in this app, it's nice to introduce simple improvements along the way that would scale well.
-
-### GraphQL
-
-The GraphiQL explorer facilitated the setup of the GraphQL API by streamlining query testing. The mutation and resolver files were set up in the `/graphql/types` folder, which are referenced in the `schema.py` file—the schema file defines the fields used in mutations or queries.
-
-Writing tests for specific GraphQL queries is also pretty straightforward—we simply use a `setUp` method from the built-in `unittest` framework that gets called before each individual test to set up a game. Then it's simply testing the GraphQL query we want (as if coming from the frontend) and making assertions on the returned data.
-
-```py
-# filepath: src/tests/graphql/test_deal_cards.py
-# ...existing code...
-class DealCardsTestCase(TestCase):
-    def setUp(self):
-        # Create a test game and some cards for testing
-        self.game = Game.objects.create(game_phase=GAME_PHASE.IN_PROGRESS.value)
-        for suit in SUIT:
-            for rank in RANK:
-                Card.objects.create(
-                    suit=suit.value,
-                    rank=rank.value,
-                    game=self.game,
-                    status=CARD_STATUS.DECK.value,
-                )
-
-    def test_deal_cards_mutation(self):
-        # GraphQL mutation query
-        mutation_query = """
-            mutation DealCardsMutation($count: Int!) {
-                dealCards(count: $count) {
-                    success
-                    message
-                    dealtCards {
-                        id
-                        suit
-                        status
-                        rank
-                    }
-                    cardsLeftInDeck
-                    acesLeftInDeck
-                }
-            }
-        """
-
-        # Set the count for dealing cards
-        count = 5
-
-        # Create a GraphQL client
-        client = Client()
-
-        # Execute the mutation with the specified count
-        response = client.post(
-            "/graphql/",
-            json.dumps(
-                {
-                    "query": mutation_query,
-                    "variables": {"count": count},
-                }
-            ),
-            content_type="application/json",
-        )
-
-        # Check if the response status code is 200
-        assert response.status_code == 200
-        self.assertEqual(len(data["data"]["dealCards"]["dealtCards"]), 5)
-        # among other assertions
-# ...existing code...
-```
-
-### If more time allowed for the back end:
-
-- Define more GraphQL return types—this was something that looked like a common GraphQL pattern, just ran out of time here.
-- Further normalize the DB—maybe a lookup table for the `card` `status` column.
-  - Possibly set up a DB repository pattern.
-- Consider adding a domain layer of pure/deterministic business logic functions.
-- Rate limit some of the API requests—i.e., I believe resetting the DB too quickly can cause issues (if the user clicks reset one too many times).
-- Install `ptw` to watch and rerun tests more easily.
-- Following GraphQL best practices, it would be more idiomatic to use nested fields.
-
-## Putting it all together
-
-After ensuring the frontend and backend worked and were fully tested, I followed a few steps to integrate the full-stack application:
-
-- Installing Apollo and pointing the client to the GraphQL address in `index.tsx`.
-
-```js
-// filepath: src/index.tsx
-// ...existing code...
-const client = new ApolloClient({
-  uri: 'http://localhost:8000/graphql/',
-  cache: new InMemoryCache(),
-});
-
-ReactDOM.render(
-  <React.StrictMode>
-    <Provider store={setupStore()}>
-      <ApolloProvider client={client}>
-        <App />
-      </ApolloProvider>
-    </Provider>
-  </React.StrictMode>,
-  document.getElementById('root')
-);
-
-reportWebVitals();
-// ...existing code...
-```
-
-- Removing the frontend in-memory storage and instead referencing the GraphQL returned data.
-- I set up a `codegen` file using the `@graphql-codegen/cli` that would take the GraphQL types defined on the backend and generate a set of TypeScript types that I could use on the frontend. This required me to go back and update a lot of the frontend enums and utility functions with those types.
-
-## Conclusion
-
-Working with familiar languages while learning new frameworks and libraries was an engaging experience. There are a few final next steps I was considering:
-
-### Additional items if more time allowed for the project:
-
-- Set loading state prior to GraphQL calls (and between deals/resets)—although it's pretty quick to make a mutation and get the result, it might make sense to have the loader show momentarily.
-- E2E tests—it would have been nice to add some Playwright tests to get additional behavioral coverage.
-- Data fetching—I didn't have time to get into it, but there is `Redux Toolkit Query` and I would be curious how that might overlap, enhance, or work in combination with GraphQL and the Apollo client.
-- Synchronizing the backend database state with the Redux store felt somewhat redundant; relying solely on the backend might suffice for this type of app. However, I kept Redux to gain experience with `redux-toolkit`.
-- Deploy the full-stack app to Vercel (it works fine locally for now)—right now just the frontend is deployed, though it functions exactly the same as the full-stack app.
+The standalone frontend and the local full-stack integration intentionally remain separate delivery modes. Redux continues to represent the client-side game state even when the GraphQL-backed version is used, which kept the learning focus on both state-management approaches rather than reducing the application to only one of them.

--- a/docs/superpowers/plans/2026-07-26-card-game-case-study.md
+++ b/docs/superpowers/plans/2026-07-26-card-game-case-study.md
@@ -1,0 +1,63 @@
+# Card Game Case Study Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Turn the Card Game project page into a concise, credible senior-level case study.
+
+**Architecture:** Keep the existing Markdown/frontmatter content system and edit only the Card Game article plus this plan. Reorganize verified facts already present in the article and, when useful, facts verifiable from the linked public repository; do not invent metrics, users, ownership, or production impact.
+
+**Tech Stack:** Markdown, gray-matter, Next.js static generation.
+
+## Global Constraints
+
+- Preserve the current title, slug, date, image, tags, source URL, and frontend demo URL unless a link is demonstrably invalid.
+- Lead with the problem, Ryan's role, constraints, key decisions, outcome, and evidence.
+- State clearly that the public demo is the standalone frontend and that the Django/GraphQL/PostgreSQL integration ran locally.
+- Remove all `...existing code...` artifacts and every “If more time allowed” or apologetic backlog section.
+- Keep only short code excerpts that prove an architectural or testing decision; every excerpt must be syntactically coherent.
+- Do not claim users, adoption, business impact, performance gains, or metrics that are not documented.
+
+---
+
+### Task 1: Rewrite the Card Game article
+
+**Files:**
+
+- Modify: `content/project/card-game.md`
+- Create: `docs/superpowers/plans/2026-07-26-card-game-case-study.md`
+
+**Interfaces:**
+
+- Consumes: the existing frontmatter schema in `lib/content.ts`.
+- Produces: the same `cardgame` project route and card metadata with a shorter case-study body.
+
+- [ ] **Step 1: Verify source facts**
+
+Read the current article and inspect the linked public repository with read-only GitHub commands. Record no claim that cannot be traced to one of those sources.
+
+- [ ] **Step 2: Replace the article body**
+
+Use this section order: `Overview`, `Problem and constraints`, `Architecture and key decisions`, `Testing and delivery`, `Outcome and tradeoffs`. Prefer paragraphs and compact bullets over a chronological tutorial.
+
+- [ ] **Step 3: Validate the Markdown**
+
+Run:
+
+```powershell
+npx prettier --check content/project/card-game.md docs/superpowers/plans/2026-07-26-card-game-case-study.md
+npm run build
+npx playwright test tests/content-pages.spec.ts
+```
+
+Expected: all commands exit 0 and `/projects/cardgame` is generated.
+
+- [ ] **Step 4: Self-review**
+
+Search for `existing code`, `if more time`, `wish`, and unverifiable numeric claims. Confirm the frontmatter contract is unchanged.
+
+- [ ] **Step 5: Commit**
+
+```powershell
+git add content/project/card-game.md docs/superpowers/plans/2026-07-26-card-game-case-study.md
+git commit -m "Rewrite the Card Game case study"
+```


### PR DESCRIPTION
## Summary
- Rework the Card Game article into a concise case study grounded in the article and public repository.
- Preserve frontmatter and make the standalone demo/local full-stack boundary explicit.
- Add the approved implementation plan.

## Verification
- `npx prettier --check content/project/card-game.md docs/superpowers/plans/2026-07-26-card-game-case-study.md`
- `npm run build`
- `npx playwright test tests/content-pages.spec.ts` (3 passed)
- `npm run test:e2e` (24 passed)