### PR TITLE
Add published Nava work highlights

### DIFF
--- a/components/styles/about.styles.ts
+++ b/components/styles/about.styles.ts
@@ -98,6 +98,16 @@ export const StyledAbout = styled.section`
     font-variant-numeric: tabular-nums;
   }
 
+  .experienceHighlights {
+    flex-basis: 100%;
+    margin: 0.15em 0 0;
+    padding-left: 1.25em;
+
+    li {
+      padding: 0.15em 0;
+    }
+  }
+
   .skillGroups {
     margin: 0;
   }
@@ -166,6 +176,10 @@ export const StyledAbout = styled.section`
 
     .entryMeta {
       margin-left: 0;
+    }
+
+    .experienceHighlights {
+      padding-left: 1.1em;
     }
 
     .skillGroup dt {

--- a/components/styles/about.styles.ts
+++ b/components/styles/about.styles.ts
@@ -68,8 +68,8 @@ export const StyledAbout = styled.section`
     margin: 0;
   }
 
-  .timeline li,
-  .credentials li {
+  .timeline > li,
+  .credentials > li {
     display: flex;
     flex-wrap: wrap;
     align-items: baseline;
@@ -78,8 +78,8 @@ export const StyledAbout = styled.section`
     border-bottom: 1px solid var(--border-color);
   }
 
-  .timeline li:last-child,
-  .credentials li:last-child {
+  .timeline > li:last-child,
+  .credentials > li:last-child {
     border-bottom: none;
   }
 
@@ -168,8 +168,8 @@ export const StyledAbout = styled.section`
 
     /* Stacked rows read better than a squeezed two-column layout, so the date
        column drops below the entry instead of being pushed to the right edge. */
-    .timeline li,
-    .credentials li {
+    .timeline > li,
+    .credentials > li {
       flex-direction: column;
       gap: 0.15em;
     }

--- a/docs/superpowers/plans/2026-07-26-work-highlights.md
+++ b/docs/superpowers/plans/2026-07-26-work-highlights.md
@@ -1,0 +1,80 @@
+# Work Highlights Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add concrete, already-public evidence of Ryan's Nava scope and outcomes to the About page and chat profile context.
+
+**Architecture:** Extend the profile experience schema with optional highlight strings, put the published résumé bullets in `me/profile.json`, render them beneath the corresponding timeline entry, and include them in the generated chat summary. The profile remains the single source of truth.
+
+**Tech Stack:** TypeScript, JSON, React, Emotion, Playwright, profile summary generator.
+
+## Global Constraints
+
+- Use only claims already published in `public/Ryan-Lewis-Resume.pdf`.
+- Add these Nava facts without embellishment:
+  - Streamlined the Massachusetts Paid Family and Medical Leave application process, reducing completion time by 30% and monthly appeals by 20%.
+  - Contributed to a CMS React/Node application that shortened cloud onboarding from months to weeks.
+  - Updated AWS infrastructure to remove critical vulnerabilities and meet CMS security standards.
+- Do not identify clients, systems, team sizes, budgets, traffic, or implementation details beyond the résumé.
+- Keep highlights optional so the other experience entries remain valid.
+- Preserve the existing company/title/date timeline and mobile layout.
+
+---
+
+### Task 1: Add red-first About-page coverage
+
+**Files:**
+
+- Modify: `tests/about-page.spec.ts`
+- Modify: `lib/profile.ts`
+- Modify: `me/profile.json`
+- Modify: `pages/about.tsx`
+- Modify: `components/styles/about.styles.ts`
+- Modify: `scripts/generate-summary.ts`
+- Modify: `me/summary.txt`
+
+**Interfaces:**
+
+- Produces: `Experience.highlights?: string[]`, rendered as a nested list and serialized into the profile summary.
+
+- [ ] **Step 1: Write the failing test**
+
+Locate the Nava timeline entry and assert that it contains a three-item highlights list with the published outcome, onboarding, and security language.
+
+- [ ] **Step 2: Verify RED**
+
+Run `npx playwright test tests/about-page.spec.ts`.
+
+Expected: failure because the Nava entry currently contains only company, title, and dates.
+
+- [ ] **Step 3: Add the profile data and type**
+
+Add optional `highlights` to `Experience` and the three exact claims to Nava's profile entry. Do not add unsupported facts to other jobs.
+
+- [ ] **Step 4: Render and style highlights**
+
+Render a nested list only when highlights are present. Keep the list inside the matching timeline item, make it span the row on desktop, and retain readable indentation on mobile.
+
+- [ ] **Step 5: Keep chat context aligned**
+
+Update `generate-summary.ts` so each experience headline is followed by its optional highlights. Run `npm run generate:summary` and commit the resulting `me/summary.txt`.
+
+- [ ] **Step 6: Verify GREEN and regression coverage**
+
+Run:
+
+```powershell
+npx playwright test tests/about-page.spec.ts
+npx prettier --check tests/about-page.spec.ts lib/profile.ts me/profile.json pages/about.tsx components/styles/about.styles.ts scripts/generate-summary.ts docs/superpowers/plans/2026-07-26-work-highlights.md
+npm run build
+npm run test:e2e
+```
+
+Expected: every command exits 0 and the generated summary contains the same three Nava facts. Restore unrelated generated build drift before committing.
+
+- [ ] **Step 7: Commit**
+
+```powershell
+git add tests/about-page.spec.ts lib/profile.ts me/profile.json pages/about.tsx components/styles/about.styles.ts scripts/generate-summary.ts me/summary.txt docs/superpowers/plans/2026-07-26-work-highlights.md
+git commit -m "Add published Nava work highlights"
+```

--- a/lib/profile.ts
+++ b/lib/profile.ts
@@ -5,6 +5,7 @@ export interface Experience {
   title: string;
   start: string;
   end: string;
+  highlights?: string[];
 }
 
 export interface Education {

--- a/me/profile.json
+++ b/me/profile.json
@@ -12,7 +12,12 @@
       "company": "Nava",
       "title": "Senior Software Engineer",
       "start": "Oct 2021",
-      "end": "Present"
+      "end": "Present",
+      "highlights": [
+        "Streamlined the Massachusetts Paid Family and Medical Leave application process, reducing completion time by 30% and monthly appeals by 20%.",
+        "Contributed to a CMS React/Node application that shortened cloud onboarding from months to weeks.",
+        "Updated AWS infrastructure to remove critical vulnerabilities and meet CMS security standards."
+      ]
     },
     {
       "company": "Wells Fargo",

--- a/me/summary.txt
+++ b/me/summary.txt
@@ -8,6 +8,9 @@ Outside of work I'm usually exploring New York's food scene, cooking, running, t
 
 WORK EXPERIENCE:
 - Nava - Senior Software Engineer (Oct 2021 - Present)
+  - Streamlined the Massachusetts Paid Family and Medical Leave application process, reducing completion time by 30% and monthly appeals by 20%.
+  - Contributed to a CMS React/Node application that shortened cloud onboarding from months to weeks.
+  - Updated AWS infrastructure to remove critical vulnerabilities and meet CMS security standards.
 - Wells Fargo - Front End Developer (Dec 2017 - Jul 2021)
 - Children's Council of San Francisco - Web Developer (Feb 2016 - Dec 2017)
 - Kaiser Permanente Division of Research - Web Developer (Jul 2010 - Feb 2016)

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -75,13 +75,13 @@ const About = () => {
                   <span className="entryMeta">
                     {job.start} – {job.end}
                   </span>
-                  {job.highlights?.length && (
+                  {job.highlights?.length ? (
                     <ul className="experienceHighlights">
                       {job.highlights.map((highlight) => (
                         <li key={highlight}>{highlight}</li>
                       ))}
                     </ul>
-                  )}
+                  ) : null}
                 </li>
               ))}
             </ol>

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -75,6 +75,13 @@ const About = () => {
                   <span className="entryMeta">
                     {job.start} – {job.end}
                   </span>
+                  {job.highlights?.length && (
+                    <ul className="experienceHighlights">
+                      {job.highlights.map((highlight) => (
+                        <li key={highlight}>{highlight}</li>
+                      ))}
+                    </ul>
+                  )}
                 </li>
               ))}
             </ol>

--- a/scripts/generate-summary.ts
+++ b/scripts/generate-summary.ts
@@ -50,9 +50,10 @@ function buildSummary(profile: Profile): string {
   sections.push(
     [
       'WORK EXPERIENCE:',
-      ...profile.experience.map(
-        (job) => `- ${job.company} - ${job.title} (${job.start} - ${job.end})`
-      ),
+      ...profile.experience.flatMap((job) => [
+        `- ${job.company} - ${job.title} (${job.start} - ${job.end})`,
+        ...(job.highlights ?? []).map((highlight) => `  - ${highlight}`),
+      ]),
     ].join('\n')
   );
 

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -1,21 +1,21 @@
-import { test, expect } from "@playwright/test";
-import { profile } from "../lib/profile";
+import { test, expect } from '@playwright/test';
+import { profile } from '../lib/profile';
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/about");
+  await page.goto('/about');
 });
 
-test("about page states role and location", async ({ page }) => {
+test('about page states role and location', async ({ page }) => {
   await expect(
-    page.getByRole("heading", { name: `About ${profile.name}`, level: 1 })
+    page.getByRole('heading', { name: `About ${profile.name}`, level: 1 })
   ).toBeVisible();
   await expect(
     page.getByText(`${profile.role} · ${profile.location}`)
   ).toBeVisible();
 });
 
-test("about page lists every role in the profile", async ({ page }) => {
-  const entries = page.locator("main .timeline li");
+test('about page lists every role in the profile', async ({ page }) => {
+  const entries = page.locator('main .timeline > li');
   await expect(entries).toHaveCount(profile.experience.length);
 
   for (const job of profile.experience) {
@@ -26,8 +26,27 @@ test("about page lists every role in the profile", async ({ page }) => {
   }
 });
 
-test("about page lists education and certifications", async ({ page }) => {
-  const entries = page.locator("main .credentials li");
+test('about page shows published Nava work highlights', async ({ page }) => {
+  const navaEntry = page
+    .locator('main .timeline > li')
+    .filter({ hasText: 'Nava' });
+  const highlights = navaEntry.locator('ul');
+
+  await expect(highlights).toHaveCount(1);
+  await expect(highlights.locator('> li')).toHaveCount(3);
+  await expect(highlights).toContainText(
+    'Streamlined the Massachusetts Paid Family and Medical Leave application process, reducing completion time by 30% and monthly appeals by 20%.'
+  );
+  await expect(highlights).toContainText(
+    'Contributed to a CMS React/Node application that shortened cloud onboarding from months to weeks.'
+  );
+  await expect(highlights).toContainText(
+    'Updated AWS infrastructure to remove critical vulnerabilities and meet CMS security standards.'
+  );
+});
+
+test('about page lists education and certifications', async ({ page }) => {
+  const entries = page.locator('main .credentials li');
   await expect(entries).toHaveCount(
     profile.education.length + profile.certifications.length
   );
@@ -48,14 +67,14 @@ test("about page lists education and certifications", async ({ page }) => {
   }
 });
 
-test("about page lists every skill in the profile", async ({ page }) => {
-  const skills = page.locator("main .skillGroups");
-  await expect(page.locator("main .skillGroup")).toHaveCount(
+test('about page lists every skill in the profile', async ({ page }) => {
+  const skills = page.locator('main .skillGroups');
+  await expect(page.locator('main .skillGroup')).toHaveCount(
     profile.skills.length
   );
 
   for (const group of profile.skills) {
-    await expect(skills.locator("dt", { hasText: group.group })).toBeVisible();
+    await expect(skills.locator('dt', { hasText: group.group })).toBeVisible();
     for (const item of group.items) {
       // Exact matching: "React" would otherwise also match the
       // "React Testing Library" pill and trip strict mode.
@@ -65,11 +84,11 @@ test("about page lists every skill in the profile", async ({ page }) => {
 });
 
 // Contact details are the footer's job, so the page body must not repeat them.
-test("about page leaves contact details to the footer", async ({ page }) => {
-  const main = page.locator("main");
+test('about page leaves contact details to the footer', async ({ page }) => {
+  const main = page.locator('main');
 
-  await expect(main.getByRole("link", { name: "LinkedIn" })).toHaveCount(0);
-  await expect(main.getByRole("link", { name: "GitHub" })).toHaveCount(0);
+  await expect(main.getByRole('link', { name: 'LinkedIn' })).toHaveCount(0);
+  await expect(main.getByRole('link', { name: 'GitHub' })).toHaveCount(0);
   await expect(
     main.locator(`a[href="mailto:${profile.links.email}"]`)
   ).toHaveCount(0);
@@ -77,14 +96,14 @@ test("about page leaves contact details to the footer", async ({ page }) => {
 
 // Passes in both states: it asserts the résumé is absent while
 // links.resume is null, and asserts it actually serves a PDF once set.
-test("resume link matches the profile configuration", async ({
+test('resume link matches the profile configuration', async ({
   page,
   request,
 }) => {
-  const navResume = page.locator("nav").getByRole("link", { name: "Resume" });
+  const navResume = page.locator('nav').getByRole('link', { name: 'Resume' });
   const aboutResume = page
-    .locator("main")
-    .getByRole("link", { name: "Résumé (PDF)" });
+    .locator('main')
+    .getByRole('link', { name: 'Résumé (PDF)' });
 
   if (!profile.links.resume) {
     await expect(navResume).toHaveCount(0);
@@ -92,10 +111,10 @@ test("resume link matches the profile configuration", async ({
     return;
   }
 
-  await expect(navResume).toHaveAttribute("href", profile.links.resume);
-  await expect(aboutResume).toHaveAttribute("href", profile.links.resume);
+  await expect(navResume).toHaveAttribute('href', profile.links.resume);
+  await expect(aboutResume).toHaveAttribute('href', profile.links.resume);
 
   const response = await request.get(profile.links.resume);
   expect(response.status()).toBe(200);
-  expect(response.headers()["content-type"]).toContain("pdf");
+  expect(response.headers()['content-type']).toContain('pdf');
 });

--- a/tests/about-page.spec.ts
+++ b/tests/about-page.spec.ts
@@ -31,18 +31,16 @@ test('about page shows published Nava work highlights', async ({ page }) => {
     .locator('main .timeline > li')
     .filter({ hasText: 'Nava' });
   const highlights = navaEntry.locator('ul');
+  const highlightItems = highlights.locator('> li');
 
   await expect(highlights).toHaveCount(1);
-  await expect(highlights.locator('> li')).toHaveCount(3);
-  await expect(highlights).toContainText(
-    'Streamlined the Massachusetts Paid Family and Medical Leave application process, reducing completion time by 30% and monthly appeals by 20%.'
-  );
-  await expect(highlights).toContainText(
-    'Contributed to a CMS React/Node application that shortened cloud onboarding from months to weeks.'
-  );
-  await expect(highlights).toContainText(
-    'Updated AWS infrastructure to remove critical vulnerabilities and meet CMS security standards.'
-  );
+  await expect(highlightItems).toHaveText([
+    'Streamlined the Massachusetts Paid Family and Medical Leave application process, reducing completion time by 30% and monthly appeals by 20%.',
+    'Contributed to a CMS React/Node application that shortened cloud onboarding from months to weeks.',
+    'Updated AWS infrastructure to remove critical vulnerabilities and meet CMS security standards.',
+  ]);
+  await expect(highlightItems.first()).toHaveCSS('display', 'list-item');
+  await expect(highlightItems.first()).toHaveCSS('border-bottom-width', '0px');
 });
 
 test('about page lists education and certifications', async ({ page }) => {


### PR DESCRIPTION
## Summary
- add the three published Nava résumé highlights to the About timeline
- keep profile summary context aligned from the profile source of truth
- cover the highlights with About-page Playwright coverage

## Verification
- 
px prettier --check ...`n- 
pm run build`n- 
px playwright test --workers=1 (25 passed, isolated worktree server)