### PR TITLE
Generate only content-backed taxonomy routes

### DIFF
--- a/docs/superpowers/plans/2026-07-27-taxonomy-route-cleanup.md
+++ b/docs/superpowers/plans/2026-07-27-taxonomy-route-cleanup.md
@@ -1,0 +1,210 @@
+# Taxonomy Route Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Generate book/project tag routes and book category routes only for configured taxonomy values used by that content type.
+
+**Architecture:** A reusable markdown-content helper exposes unique tag or category values per content type. Each dynamic route filters its metadata configuration through those used values before returning paths, while `fallback: false` provides 404 behavior for omitted values.
+
+**Tech Stack:** Next.js Pages Router, TypeScript, Node test runner through `tsx`, Playwright
+
+## Global Constraints
+
+- Preserve configured titles and descriptions for every retained route.
+- Do not modify sitemap or robots behavior, page metadata, content frontmatter, homepage content, or unrelated presentation.
+- Derive path eligibility from actual markdown content and keep `fallback: false`.
+
+---
+
+### Task 1: Prove taxonomy path over-generation
+
+**Files:**
+
+- Create: `tests/taxonomy-paths.test.ts`
+- Modify: `tests/tag-pages.spec.ts`
+
+**Interfaces:**
+
+- Consumes: the `getStaticPaths()` exports from the three taxonomy page modules
+- Produces: regression expectations for exact generated parameters and HTTP 404 behavior
+
+- [ ] **Step 1: Write focused failing unit tests**
+
+Create tests that call each real route's `getStaticPaths()` and assert these
+literal parameter lists:
+
+```ts
+book tags: ["devops", "engineering", "management"]
+project tags: [
+  "angular",
+  "clustering",
+  "d3",
+  "dimensionality reduction",
+  "django",
+  "edtech",
+  "flask",
+  "fullstack",
+  "graphql",
+  "javascript",
+  "machine learning",
+  "mdp",
+  "omscs",
+  "optimization",
+  "policy iteration",
+  "postgres",
+  "python",
+  "q-learning",
+  "randomized algorithms",
+  "react",
+  "reinforcement learning",
+  "sklearn",
+  "value iteration",
+  "vue",
+]
+book categories: []
+```
+
+Also assert `fallback` is exactly `false`.
+
+- [ ] **Step 2: Run the unit test and verify RED**
+
+Run:
+
+```powershell
+npx tsx --test tests/taxonomy-paths.test.ts
+```
+
+Expected: FAIL because current route modules return every configured value.
+
+- [ ] **Step 3: Add failing HTTP-boundary coverage**
+
+In `tests/tag-pages.spec.ts`, request an unused book tag, an unused project tag,
+and an unused book category and expect each response status to be `404`.
+
+- [ ] **Step 4: Run the focused Playwright test and verify RED**
+
+Run:
+
+```powershell
+npx playwright test --config playwright.agent.config.ts tests/tag-pages.spec.ts -g "unused taxonomy routes return 404" --workers=1
+```
+
+Expected: FAIL because the current build emits empty pages for configured but
+unused taxonomy values.
+
+### Task 2: Filter configured paths through content-derived values
+
+**Files:**
+
+- Modify: `lib/content.ts`
+- Modify: `pages/books/tags/[tag].tsx`
+- Modify: `pages/projects/tags/[tag].tsx`
+- Modify: `pages/books/categories/[category].tsx`
+- Test: `tests/taxonomy-paths.test.ts`
+- Test: `tests/tag-pages.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `getContentList(contentType)` and each taxonomy configuration array
+- Produces: `getContentTaxonomyValues(contentType, taxonomy): string[]`
+
+- [ ] **Step 1: Implement the minimal helper**
+
+Add this public interface in `lib/content.ts`:
+
+```ts
+type ContentTaxonomy = 'tags' | 'category';
+
+export const getContentTaxonomyValues = (
+  contentType: IContentType,
+  taxonomy: ContentTaxonomy
+): string[] => {
+  const content = getContentList(contentType);
+  const values =
+    taxonomy === 'tags'
+      ? content.flatMap((item) => item.tags ?? [])
+      : content.flatMap((item) => (item.category ? [item.category] : []));
+
+  return [...new Set(values)];
+};
+```
+
+- [ ] **Step 2: Filter each route's configured values**
+
+For each `getStaticPaths()`, make a `Set` from
+`getContentTaxonomyValues(contentType, taxonomy)` and return only configured
+entries whose `tag` or `category` is present.
+
+- [ ] **Step 3: Run focused tests and verify GREEN**
+
+Run:
+
+```powershell
+npx tsx --test tests/taxonomy-paths.test.ts
+npx playwright test --config playwright.agent.config.ts tests/tag-pages.spec.ts --workers=1
+```
+
+Expected: all focused unit and Playwright tests pass.
+
+- [ ] **Step 4: Run the mutation check**
+
+Confirm that removing a route filter, using the wrong content type, or restoring
+all configured categories would fail at least one focused test.
+
+### Task 3: Verify and prepare the pull request
+
+**Files:**
+
+- Delete: `playwright.agent.config.ts`
+- Review: all files changed against `master`
+
+**Interfaces:**
+
+- Consumes: the completed implementation and regression coverage
+- Produces: one committed and pushed PR branch targeting `master`
+
+- [ ] **Step 1: Run format verification**
+
+Run:
+
+```powershell
+npx prettier --write docs/superpowers/specs/2026-07-27-taxonomy-route-cleanup-design.md docs/superpowers/plans/2026-07-27-taxonomy-route-cleanup.md lib/content.ts pages/books/tags/[tag].tsx pages/projects/tags/[tag].tsx pages/books/categories/[category].tsx tests/taxonomy-paths.test.ts tests/tag-pages.spec.ts
+npm run format:check
+```
+
+- [ ] **Step 2: Run complete verification**
+
+Run:
+
+```powershell
+npm run test:unit
+npm run build
+npx playwright test --config playwright.agent.config.ts --workers=1
+```
+
+Expected: all commands exit zero.
+
+- [ ] **Step 3: Remove temporary and generated drift**
+
+Delete `playwright.agent.config.ts`, restore only unrelated generated files
+changed by build or test runs, and confirm the diff contains the approved
+taxonomy scope.
+
+- [ ] **Step 4: Self-review against master**
+
+Review:
+
+```powershell
+git diff --check master...HEAD
+git diff --stat master
+git diff master -- docs/superpowers lib/content.ts pages/books/tags/[tag].tsx pages/projects/tags/[tag].tsx pages/books/categories/[category].tsx tests/taxonomy-paths.test.ts tests/tag-pages.spec.ts
+```
+
+Check path/content correspondence, retained metadata behavior, 404 coverage,
+formatting, and scope exclusions.
+
+- [ ] **Step 5: Commit, push, and create the PR**
+
+Commit the final diff, push `tier3/taxonomy-cleanup`, then create a GitHub pull
+request targeting `master` with the rationale and exact verification evidence.
+Do not merge it.

--- a/docs/superpowers/specs/2026-07-27-taxonomy-route-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-27-taxonomy-route-cleanup-design.md
@@ -1,0 +1,60 @@
+# Taxonomy Route Cleanup Design
+
+## Problem
+
+The three dynamic taxonomy pages currently generate paths from every configured
+tag or category. That creates empty book-tag, project-tag, and book-category
+pages when a configured value is unused by that content type.
+
+## Scope
+
+Change static path generation for:
+
+- `/books/tags/[tag]`
+- `/projects/tags/[tag]`
+- `/books/categories/[category]`
+
+Do not change sitemap or robots behavior, metadata, content frontmatter,
+homepage content, or page presentation.
+
+## Design
+
+Add a reusable content helper in `lib/content.ts` that returns the unique
+taxonomy values present in a requested content type. It will support tag and
+category values and derive them from the existing markdown-backed content list.
+
+Each taxonomy page will keep its configuration file as the source of route
+titles and descriptions, but filter that configuration against the values
+returned by the content helper before producing static paths. This means:
+
+- a configured route builds only when at least one item of that content type
+  uses its taxonomy value;
+- book and project tag paths remain independent;
+- unused and unknown values are absent from `getStaticPaths`;
+- `fallback: false` makes absent paths resolve as 404;
+- retained routes continue to use their configured title and description.
+
+Content values that lack configuration will not produce a route. Existing
+coverage that requires all content tags to exist in `config/tags.json` remains
+the guard for tag configuration completeness.
+
+## Testing
+
+Add focused unit coverage that calls the real `getStaticPaths` exports and
+compares their parameters with literal taxonomy values derived independently
+from the repository's current content. The test must fail against the existing
+over-generation.
+
+Add Playwright coverage that verifies a retained route renders content and
+representative unused taxonomy URLs return 404. Run Playwright against an
+isolated local server because `fallback: false` behavior is observable at the
+HTTP boundary.
+
+## Success Criteria
+
+- Every generated taxonomy path has at least one matching item of its content
+  type.
+- No unused book tag, project tag, or book category path is generated.
+- Representative unused taxonomy URLs return 404.
+- Retained routes preserve configured titles and descriptions.
+- Unit tests, build, formatting, and relevant/full Playwright coverage pass.

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -15,6 +15,7 @@ const projectDirectory = path.join(process.cwd(), 'content', 'project');
 const bookDirectory = path.join(process.cwd(), 'content', 'book');
 
 type IContentType = 'book' | 'project';
+type ContentTaxonomy = 'tags' | 'category';
 
 // Interface for content list items (used in listings)
 export interface ContentListItem {
@@ -148,7 +149,9 @@ export const getContentData = async (id: string, contentType: IContentType) => {
  * @param {string} contentType Type of content
  * For the landing page of each subpage - called from book/project.tsx getStaticProps
  */
-export const getContentList = (contentType: IContentType): ContentListItem[] => {
+export const getContentList = (
+  contentType: IContentType
+): ContentListItem[] => {
   let contentFiles: string[];
   let contentDir: string;
 
@@ -184,12 +187,28 @@ export const getContentList = (contentType: IContentType): ContentListItem[] => 
   return content.sort(sortByDate);
 };
 
+export const getContentTaxonomyValues = (
+  contentType: IContentType,
+  taxonomy: ContentTaxonomy
+): string[] => {
+  const content = getContentList(contentType);
+  const values =
+    taxonomy === 'tags'
+      ? content.flatMap((item) => item.tags ?? [])
+      : content.flatMap((item) => (item.category ? [item.category] : []));
+
+  return [...new Set(values)];
+};
+
 /**
  * Get content type with particular tag
  * @param {string} tag - tag to filter by
  * called from [id].tsx getStaticPaths
  */
-export const getContentWithTag = (tag: string, contentType: IContentType): ContentListItem[] => {
+export const getContentWithTag = (
+  tag: string,
+  contentType: IContentType
+): ContentListItem[] => {
   let contentDir: string | undefined;
   let contentFiles: string[];
 

--- a/pages/books/categories/[category].tsx
+++ b/pages/books/categories/[category].tsx
@@ -4,7 +4,11 @@ import { GetStaticPropsContext } from 'next';
 import { Container, Layout } from '../../../components';
 import NotesComponent from '../../../components/notes/notes';
 import categoryJSON from '../../../config/categories.json';
-import { getContentInCategory, ContentListItem } from '../../../lib/content';
+import {
+  getContentInCategory,
+  getContentTaxonomyValues,
+  ContentListItem,
+} from '../../../lib/content';
 
 interface CategoryPageProps {
   content: ContentListItem[];
@@ -25,14 +29,17 @@ const Category = ({ content, title, description }: CategoryPageProps) => {
 };
 
 export const getStaticPaths = async () => {
-  // Get all the tags from the already defined site tags
-  const paths = categoryJSON.map((category) => {
-    return {
-      params: {
-        category: category.category,
-      },
-    };
-  });
+  const bookCategories = new Set(getContentTaxonomyValues('book', 'category'));
+
+  const paths = categoryJSON
+    .filter((category) => bookCategories.has(category.category))
+    .map((category) => {
+      return {
+        params: {
+          category: category.category,
+        },
+      };
+    });
 
   return {
     paths,

--- a/pages/books/tags/[tag].tsx
+++ b/pages/books/tags/[tag].tsx
@@ -3,7 +3,11 @@ import React from 'react';
 import { GetStaticPropsContext } from 'next';
 import { Cards, Container, Layout } from '../../../components';
 import tagsJSON from '../../../config/tags.json';
-import { getContentWithTag, ContentListItem } from '../../../lib/content';
+import {
+  getContentTaxonomyValues,
+  getContentWithTag,
+  ContentListItem,
+} from '../../../lib/content';
 
 interface TagPageProps {
   content: ContentListItem[];
@@ -25,15 +29,17 @@ const Tag = ({ content, title, description }: TagPageProps) => {
 };
 
 export const getStaticPaths = async () => {
-  // Get all the tags from the already defined site tags
+  const bookTags = new Set(getContentTaxonomyValues('book', 'tags'));
 
-  const paths = tagsJSON.map((tag) => {
-    return {
-      params: {
-        tag: tag.tag,
-      },
-    };
-  });
+  const paths = tagsJSON
+    .filter((tag) => bookTags.has(tag.tag))
+    .map((tag) => {
+      return {
+        params: {
+          tag: tag.tag,
+        },
+      };
+    });
 
   return {
     paths,

--- a/pages/projects/tags/[tag].tsx
+++ b/pages/projects/tags/[tag].tsx
@@ -3,7 +3,11 @@ import React from 'react';
 import { GetStaticPropsContext } from 'next';
 import { Cards, Container, Layout } from '../../../components';
 import tagsJSON from '../../../config/tags.json';
-import { getContentWithTag, ContentListItem } from '../../../lib/content';
+import {
+  getContentTaxonomyValues,
+  getContentWithTag,
+  ContentListItem,
+} from '../../../lib/content';
 
 interface TagPageProps {
   content: ContentListItem[];
@@ -25,15 +29,17 @@ const Tag = ({ content, title, description }: TagPageProps) => {
 };
 
 export const getStaticPaths = async () => {
-  // Get all the tags from the already defined site tags
+  const projectTags = new Set(getContentTaxonomyValues('project', 'tags'));
 
-  const paths = tagsJSON.map((tag) => {
-    return {
-      params: {
-        tag: tag.tag,
-      },
-    };
-  });
+  const paths = tagsJSON
+    .filter((tag) => projectTags.has(tag.tag))
+    .map((tag) => {
+      return {
+        params: {
+          tag: tag.tag,
+        },
+      };
+    });
 
   return {
     paths,

--- a/tests/tag-pages.spec.ts
+++ b/tests/tag-pages.spec.ts
@@ -1,12 +1,12 @@
-import { test, expect } from "@playwright/test";
-import tagsJSON from "../config/tags.json";
-import { getContentList, getContentWithTag } from "../lib/content";
-import { TAG_CATEGORIES } from "../components/chips/chips";
+import { test, expect } from '@playwright/test';
+import tagsJSON from '../config/tags.json';
+import { getContentList, getContentWithTag } from '../lib/content';
+import { TAG_CATEGORIES } from '../components/chips/chips';
 
 const siteTags = new Set(tagsJSON.map((tag) => tag.tag));
 
 const escapeRegExp = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 const pickTaggedEntry = (content) => {
   return content.find(
@@ -15,22 +15,22 @@ const pickTaggedEntry = (content) => {
   );
 };
 
-test("project tags link to the full tagged list", async ({ page }) => {
-  const projects = getContentList("project");
+test('project tags link to the full tagged list', async ({ page }) => {
+  const projects = getContentList('project');
   const taggedProject = pickTaggedEntry(projects);
 
   expect(taggedProject).toBeTruthy();
   if (!taggedProject) {
-    throw new Error("No projects matched tags in config/tags.json.");
+    throw new Error('No projects matched tags in config/tags.json.');
   }
 
   const tag = taggedProject.tags.find((value) => siteTags.has(value));
   if (!tag) {
-    throw new Error("No project tags matched tags in config/tags.json.");
+    throw new Error('No project tags matched tags in config/tags.json.');
   }
 
   await page.goto(`/projects/${taggedProject.slug}`);
-  const tagLink = page.locator("main").getByRole("link", { name: tag }).first();
+  const tagLink = page.locator('main').getByRole('link', { name: tag }).first();
   await expect(tagLink).toBeVisible();
   await Promise.all([
     page.waitForURL(
@@ -44,34 +44,34 @@ test("project tags link to the full tagged list", async ({ page }) => {
     new RegExp(`/projects/tags/${escapeRegExp(encodeURIComponent(tag))}$`)
   );
 
-  const taggedProjects = getContentWithTag(tag, "project");
-  const headings = page.locator("main article h2");
+  const taggedProjects = getContentWithTag(tag, 'project');
+  const headings = page.locator('main article h2');
 
   await expect(headings).toHaveCount(taggedProjects.length);
   for (const project of taggedProjects) {
     await expect(
-      page.locator("main").getByRole("heading", { name: project.title })
+      page.locator('main').getByRole('heading', { name: project.title })
     ).toBeVisible();
   }
 });
 
-test("book tags link to the full tagged list", async ({ page }) => {
+test('book tags link to the full tagged list', async ({ page }) => {
   test.setTimeout(60_000);
-  const books = getContentList("book");
+  const books = getContentList('book');
   const taggedBook = pickTaggedEntry(books);
 
   expect(taggedBook).toBeTruthy();
   if (!taggedBook) {
-    throw new Error("No books matched tags in config/tags.json.");
+    throw new Error('No books matched tags in config/tags.json.');
   }
 
   const tag = taggedBook.tags.find((value) => siteTags.has(value));
   if (!tag) {
-    throw new Error("No book tags matched tags in config/tags.json.");
+    throw new Error('No book tags matched tags in config/tags.json.');
   }
 
   await page.goto(`/books/${taggedBook.slug}`);
-  const tagLink = page.locator("main").getByRole("link", { name: tag }).first();
+  const tagLink = page.locator('main').getByRole('link', { name: tag }).first();
   await expect(tagLink).toBeVisible();
   await Promise.all([
     page.waitForURL(
@@ -85,20 +85,20 @@ test("book tags link to the full tagged list", async ({ page }) => {
     new RegExp(`/books/tags/${escapeRegExp(encodeURIComponent(tag))}$`)
   );
 
-  const taggedBooks = getContentWithTag(tag, "book");
-  const headings = page.locator("main article h2");
+  const taggedBooks = getContentWithTag(tag, 'book');
+  const headings = page.locator('main article h2');
 
   await expect(headings).toHaveCount(taggedBooks.length);
   for (const book of taggedBooks) {
     await expect(
-      page.locator("main").getByRole("heading", { name: book.title })
+      page.locator('main').getByRole('heading', { name: book.title })
     ).toBeVisible();
   }
 });
 
-test("all content tags exist in config/tags.json", async () => {
-  const projects = getContentList("project");
-  const books = getContentList("book");
+test('all content tags exist in config/tags.json', async () => {
+  const projects = getContentList('project');
+  const books = getContentList('book');
   const contentTags = new Set(
     [...projects, ...books].flatMap((item) =>
       Array.isArray(item.tags) ? item.tags : []
@@ -110,11 +110,37 @@ test("all content tags exist in config/tags.json", async () => {
   }
 });
 
-test("every tag in config/tags.json has a known category", async () => {
+test('every tag in config/tags.json has a known category', async () => {
   for (const entry of tagsJSON) {
     expect(
       TAG_CATEGORIES,
       `tag "${entry.tag}" has category "${entry.category}"`
     ).toContain(entry.category);
+  }
+});
+
+test('unused taxonomy routes return 404', async ({ request }) => {
+  const unusedRoutes = [
+    '/books/tags/javascript',
+    '/projects/tags/management',
+    '/books/categories/weekly-notes',
+  ];
+
+  for (const route of unusedRoutes) {
+    const response = await request.get(route);
+    expect(response.status(), route).toBe(404);
+  }
+});
+
+test('unknown taxonomy routes return 404', async ({ request }) => {
+  const unknownRoutes = [
+    '/books/tags/not-configured',
+    '/projects/tags/not-configured',
+    '/books/categories/not-configured',
+  ];
+
+  for (const route of unknownRoutes) {
+    const response = await request.get(route);
+    expect(response.status(), route).toBe(404);
   }
 });

--- a/tests/taxonomy-paths.test.ts
+++ b/tests/taxonomy-paths.test.ts
@@ -1,0 +1,87 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { getStaticPaths as getBookCategoryPaths } from '../pages/books/categories/[category]';
+import {
+  getStaticPaths as getBookTagPaths,
+  getStaticProps as getBookTagProps,
+} from '../pages/books/tags/[tag]';
+import {
+  getStaticPaths as getProjectTagPaths,
+  getStaticProps as getProjectTagProps,
+} from '../pages/projects/tags/[tag]';
+
+const getParameterValues = (
+  paths: Array<{ params: Record<string, string> }>,
+  parameter: string
+) => paths.map(({ params }) => params[parameter]).sort();
+
+describe('taxonomy static paths', () => {
+  test('book tag paths include only tags used by books', async () => {
+    const result = await getBookTagPaths();
+
+    assert.equal(result.fallback, false);
+    assert.deepEqual(getParameterValues(result.paths, 'tag'), [
+      'devops',
+      'engineering',
+      'management',
+    ]);
+  });
+
+  test('project tag paths include only tags used by projects', async () => {
+    const result = await getProjectTagPaths();
+
+    assert.equal(result.fallback, false);
+    assert.deepEqual(getParameterValues(result.paths, 'tag'), [
+      'angular',
+      'clustering',
+      'd3',
+      'dimensionality reduction',
+      'django',
+      'edtech',
+      'flask',
+      'fullstack',
+      'graphql',
+      'javascript',
+      'machine learning',
+      'mdp',
+      'omscs',
+      'optimization',
+      'policy iteration',
+      'postgres',
+      'python',
+      'q-learning',
+      'randomized algorithms',
+      'react',
+      'reinforcement learning',
+      'sklearn',
+      'value iteration',
+      'vue',
+    ]);
+  });
+
+  test('book category paths exclude categories unused by books', async () => {
+    const result = await getBookCategoryPaths();
+
+    assert.equal(result.fallback, false);
+    assert.deepEqual(getParameterValues(result.paths, 'category'), []);
+  });
+
+  test('retained book tag paths keep configured metadata and content', async () => {
+    const result = await getBookTagProps({ params: { tag: 'devops' } });
+
+    assert.equal(result.props.title, 'DevOps');
+    assert.equal(result.props.description, 'DevOps practices and tooling');
+    assert.ok(result.props.content.length > 0);
+  });
+
+  test('retained project tag paths keep configured metadata and content', async () => {
+    const result = await getProjectTagProps({
+      params: { tag: 'javascript' },
+    });
+
+    assert.equal(result.props.title, 'JavaScript');
+    assert.equal(result.props.description, 'All things javascript');
+    assert.ok(result.props.content.length > 0);
+  });
+});


### PR DESCRIPTION
## Summary

- derive unique tag and category values from each markdown content type
- filter configured taxonomy metadata before generating book tag, project tag, and book category paths
- retain configured titles and descriptions for generated routes while letting unused and unknown routes fall through fallback: false to 404
- add focused static-path and HTTP-boundary regression coverage

## Why

The shared taxonomy configs currently cause every value to be generated for every applicable route family. That emits empty URLs when a tag or category is not used by that content type. Filtering configured metadata through actual content removes those empty pages without changing content, metadata, or presentation.

## Test evidence

- Changed-file Prettier check: passed
- npm run test:unit: 38 passed
- npm run build: passed; emitted 3 book tag paths, 24 project tag paths, and no book category paths
- Full Playwright against the production build on isolated port 3102 with one worker: 26 passed
- Focused red/green proof: all three path-set tests failed before implementation, and /books/tags/javascript returned 200 before changing to 404

## Formatting baseline

npm run format:check remains red on 95 unrelated pre-existing files. All tracked files changed by this PR pass the targeted Prettier check; unrelated formatting was left untouched.