### PR TITLE
Harden production defaults and Playwright CI

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -19,12 +19,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
+          cache: npm
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: npm ci
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
 
       - name: Run Playwright tests
-        run: yarn test:e2e
+        run: npm run test:e2e

--- a/docs/superpowers/plans/2026-07-27-production-hygiene.md
+++ b/docs/superpowers/plans/2026-07-27-production-hygiene.md
@@ -1,0 +1,177 @@
+# Production Hygiene Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove the unused hello API, make Playwright CI consistently use npm, and add verified low-risk response headers.
+
+**Architecture:** A root Next.js configuration applies two global response headers. A focused Playwright integration spec verifies the headers through the real server and confirms the deleted route now returns 404; the GitHub Actions workflow consumes the committed npm lockfile and existing npm script.
+
+**Tech Stack:** Next.js 16 Pages Router, TypeScript, Playwright, npm, GitHub Actions
+
+## Global Constraints
+
+- Do not add CSP in this pull request.
+- Do not use `npm audit fix --force` or accept major-version changes.
+- Do not change README, scratch files, sitemap, robots, page metadata, taxonomy, homepage, or content.
+- Run branch-specific Playwright checks on port 3103 with `reuseExistingServer: false`.
+
+---
+
+### Task 1: Specify production HTTP behavior
+
+**Files:**
+
+- Create: `tests/production-hygiene.spec.ts`
+
+**Interfaces:**
+
+- Consumes: the running Next.js server through Playwright's configured `request`
+  fixture.
+- Produces: regression coverage for `/api/hello` returning 404 and `/` returning
+  both configured security headers.
+
+- [ ] **Step 1: Write failing response tests**
+
+```ts
+import { expect, test } from '@playwright/test';
+
+test('the removed hello API returns not found', async ({ request }) => {
+  const response = await request.get('/api/hello');
+  expect(response.status()).toBe(404);
+});
+
+test('pages include the low-risk security headers', async ({ request }) => {
+  const response = await request.get('/');
+  expect(response.headers()['x-content-type-options']).toBe('nosniff');
+  expect(response.headers()['referrer-policy']).toBe(
+    'strict-origin-when-cross-origin'
+  );
+});
+```
+
+- [ ] **Step 2: Run the focused spec and verify red**
+
+Run with a temporary port-3103 Playwright config:
+`npx playwright test tests/production-hygiene.spec.ts --config playwright.agent.config.ts`
+
+Expected: the route assertion receives 200 and the header assertions receive
+`undefined`.
+
+### Task 2: Remove the route and configure headers
+
+**Files:**
+
+- Delete: `pages/api/hello.tsx`
+- Create: `next.config.js`
+
+**Interfaces:**
+
+- Consumes: Next.js `headers()` configuration contract.
+- Produces: `/api/hello` has no route; all matched responses contain
+  `X-Content-Type-Options: nosniff` and
+  `Referrer-Policy: strict-origin-when-cross-origin`.
+
+- [ ] **Step 1: Delete the unused route**
+
+Delete `pages/api/hello.tsx` without replacing it.
+
+- [ ] **Step 2: Add the minimal Next.js configuration**
+
+```js
+/** @type {import("next").NextConfig} */
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+        ],
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;
+```
+
+- [ ] **Step 3: Run the focused spec and verify green**
+
+Run:
+`npx playwright test tests/production-hygiene.spec.ts --config playwright.agent.config.ts`
+
+Expected: 2 passed.
+
+### Task 3: Align Playwright CI with npm
+
+**Files:**
+
+- Modify: `.github/workflows/playwright.yml`
+
+**Interfaces:**
+
+- Consumes: `package-lock.json` and the `test:e2e` script from `package.json`.
+- Produces: deterministic CI installation and invocation through repository npm
+  scripts.
+
+- [ ] **Step 1: Update Node setup and commands**
+
+Add `cache: npm` to `actions/setup-node`, replace
+`yarn install --frozen-lockfile` with `npm ci`, and replace `yarn test:e2e` with
+`npm run test:e2e`. Keep `npx playwright install --with-deps`.
+
+- [ ] **Step 2: Verify workflow inputs**
+
+Run:
+`git grep -n -E "cache: npm|npm ci|npx playwright install --with-deps|npm run test:e2e" -- .github/workflows/playwright.yml`
+
+Expected: all four npm/Playwright lines are present, `package-lock.json` exists,
+and `package.json` defines `"test:e2e": "playwright test"`.
+
+### Task 4: Audit and complete verification
+
+**Files:**
+
+- Modify only `package-lock.json` if `npm audit fix` offers a non-breaking
+  remediation and all checks remain green.
+
+**Interfaces:**
+
+- Consumes: the completed repository state.
+- Produces: audit evidence, test evidence, and a reviewable PR.
+
+- [ ] **Step 1: Format and inspect**
+
+Run `npm run format:check`, then inspect `git diff --check` and the complete diff
+against `master`.
+
+- [ ] **Step 2: Audit dependencies**
+
+Run `npm audit`. If npm offers a non-breaking fix, run `npm audit fix`, inspect
+the lockfile-only result, and rerun the audit. Do not run with `--force`.
+
+- [ ] **Step 3: Run unit and build verification**
+
+Run `npm run test:unit` and `npm run build`.
+
+- [ ] **Step 4: Run full isolated Playwright verification**
+
+Run:
+`npx playwright test --config playwright.agent.config.ts`
+
+Expected: all Playwright tests pass on the branch server at port 3103.
+
+- [ ] **Step 5: Remove temporary artifacts and recheck the diff**
+
+Delete `playwright.agent.config.ts`, restore unrelated generated build drift,
+and confirm `git status --short` contains only the intended files.
+
+- [ ] **Step 6: Commit, push, and open the pull request**
+
+Commit the complete reviewed change, push `tier3/production-hygiene`, and create
+a GitHub pull request targeting `master` with the verification and audit
+evidence. Do not merge.

--- a/docs/superpowers/specs/2026-07-27-production-hygiene-design.md
+++ b/docs/superpowers/specs/2026-07-27-production-hygiene-design.md
@@ -1,0 +1,61 @@
+# Production Hygiene Design
+
+## Goal
+
+Remove an unused public API route, align the Playwright workflow with the
+repository's npm lockfile and scripts, and add low-risk response security
+headers without changing site content or runtime integrations.
+
+## Scope
+
+- Delete `pages/api/hello.tsx`, making `/api/hello` resolve through the normal
+  Next.js 404 behavior.
+- Change `.github/workflows/playwright.yml` to install with `npm ci`, enable the
+  npm cache through `actions/setup-node`, and run the existing `test:e2e` npm
+  script.
+- Add a root `next.config.js` whose global `headers()` rule sets:
+  - `X-Content-Type-Options: nosniff`
+  - `Referrer-Policy: strict-origin-when-cross-origin`
+- Add Playwright coverage that observes the removed route and headers through a
+  running Next.js server.
+
+No README, scratch file, sitemap, robots, page metadata, taxonomy, homepage, or
+content changes belong in this pull request.
+
+## Design Decisions
+
+Next.js applies configured headers before filesystem routing, so one `/(.*)`
+rule will cover pages, API responses, and 404 responses. The header values match
+the current official Next.js header configuration guidance while avoiding
+behavioral changes to embedding, browser capabilities, and transport handling.
+
+The workflow will use `npm ci` because `package-lock.json` is committed. Browser
+installation remains `npx playwright install --with-deps`, and the suite will
+run through `npm run test:e2e`, which exactly matches the package script.
+
+## CSP Evaluation
+
+This pull request will not add Content Security Policy. The Pages Router
+currently uses inline scripts, Emotion styles, Next.js runtime scripts, Vercel
+Analytics, Google Tag Manager, an external Prism stylesheet, and external
+connections. The official Next.js CSP guidance notes that a strict nonce policy
+requires per-request nonces and dynamic rendering, while a static policy must
+permit inline and third-party resources. Shipping an unvalidated policy here
+could break rendering or analytics; a CSP should be designed and tested as a
+separate change.
+
+## Testing and Verification
+
+The new Playwright spec will first fail against the existing route and missing
+headers, then pass after implementation. Verification will use an isolated
+temporary Playwright configuration on port 3103 with server reuse disabled.
+Final checks include Prettier, unit tests, production build, full Playwright
+coverage, `npm audit`, workflow-to-lockfile/script inspection, and a clean diff
+against `master`.
+
+## Dependency Audit Policy
+
+Run `npm audit` and apply only remediation that npm identifies as non-breaking
+and that survives the complete verification suite. Do not use
+`npm audit fix --force` or accept major-version changes. Record any remaining
+findings in the pull request.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,22 @@
+/** @type {import("next").NextConfig} */
+const nextConfig = {
+  async headers() {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+        ],
+      },
+    ];
+  },
+};
+
+module.exports = nextConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1414,15 +1414,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.11.tgz",
-      "integrity": "sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.12.tgz",
+      "integrity": "sha512-d0Z5Bc13Fa4nR8pFAKx2jay2yhJM16vlfHbTzYnUQAxlNb6B6lmn4hjt69lYNt4kRtyYP6gEM49lPRHNbIyneg==",
       "license": "MIT"
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.11.tgz",
-      "integrity": "sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.12.tgz",
+      "integrity": "sha512-0W1R0teHWJrqKX0FH20IzzIWAOuGtBxPGuObrxy1lE8hQvCFj49KE8a3WUg0D7sq6rn6zkM4c7YGUnhudBS6oA==",
       "cpu": [
         "arm64"
       ],
@@ -1436,9 +1436,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.11.tgz",
-      "integrity": "sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.12.tgz",
+      "integrity": "sha512-Hy5Ls099+aFUmOLmIgPfLqNi6iCwhL3uQCssz5rWk+5Nkc6TUKCE83DY5BbNylfm3+mfwcSFnLRfrZDJhVxdtw==",
       "cpu": [
         "x64"
       ],
@@ -1452,9 +1452,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.11.tgz",
-      "integrity": "sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.12.tgz",
+      "integrity": "sha512-+YqU2h1cQkHsGfvjAsrSmst8UIFBibBGm5x3Xgel8NLMiDQtNOM4sM2GOEMvG5YiOBNeN/Ykk8cQC2S0Xrqljg==",
       "cpu": [
         "arm64"
       ],
@@ -1471,9 +1471,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.11.tgz",
-      "integrity": "sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.12.tgz",
+      "integrity": "sha512-0qjhiYBaKAqF63LA1ZWAAnKTzFUguAaZiRa5etMLGGPj/B6uEVjtIZldIzFEp3wHlB0koK6aTzqPtSdplTCjoA==",
       "cpu": [
         "arm64"
       ],
@@ -1490,9 +1490,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.11.tgz",
-      "integrity": "sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.12.tgz",
+      "integrity": "sha512-7A3q26W+h7gnA15uqBToNuDqBEFZZcqh0mW2mn4AJh/G5pdg2RVE3n4slzLEliASZFG3NmsbEzng/x2Sh09mBg==",
       "cpu": [
         "x64"
       ],
@@ -1509,9 +1509,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.11.tgz",
-      "integrity": "sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.12.tgz",
+      "integrity": "sha512-qSjL/uppm+cbh21s72Ss8gkiOhQ4dExWHNGOWy6eZV7STj5WsKehgxT61beSsOj+YYQuTplL376lOCdMQU5T8w==",
       "cpu": [
         "x64"
       ],
@@ -1528,9 +1528,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.11.tgz",
-      "integrity": "sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.12.tgz",
+      "integrity": "sha512-X6hzsOUJac/e7AWSbn9gQ9nzHld1xWP5iyjHpYWvud8pufB679O1xg4JDyKr8Xd69Jvd+kM2Der6uftiZCmjYA==",
       "cpu": [
         "arm64"
       ],
@@ -1544,9 +1544,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.11.tgz",
-      "integrity": "sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.12.tgz",
+      "integrity": "sha512-F6fakeHuFTLOPt0bslQJdf+xtT+WIP9DVn/m4y1w1mRnVPyh3D/cNvzlRkxM444xfm+IvvYNSOrKiA2CDJ0Uxw==",
       "cpu": [
         "x64"
       ],
@@ -2676,9 +2676,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.0.tgz",
-      "integrity": "sha512-uIFDxqpRZGZ6ThOk84hEfqWoHx2devRFvpTZcTHur85vImfaxUbTW9Ryh4CpCuDnToOP1CEtXKIgytHBPVff5A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3143,9 +3143,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -4050,12 +4050,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.11",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.11.tgz",
-      "integrity": "sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==",
+      "version": "16.2.12",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.12.tgz",
+      "integrity": "sha512-iD59eYQWmbFcEbX7v/acG5DRym9iw1DdaPoD0WTA920naWsE25wShzJW4+UvAs8MK9EC2kBfIH6vtto1H1PHGw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.11",
+        "@next/env": "16.2.12",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -4069,14 +4069,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.11",
-        "@next/swc-darwin-x64": "16.2.11",
-        "@next/swc-linux-arm64-gnu": "16.2.11",
-        "@next/swc-linux-arm64-musl": "16.2.11",
-        "@next/swc-linux-x64-gnu": "16.2.11",
-        "@next/swc-linux-x64-musl": "16.2.11",
-        "@next/swc-win32-arm64-msvc": "16.2.11",
-        "@next/swc-win32-x64-msvc": "16.2.11",
+        "@next/swc-darwin-arm64": "16.2.12",
+        "@next/swc-darwin-x64": "16.2.12",
+        "@next/swc-linux-arm64-gnu": "16.2.12",
+        "@next/swc-linux-arm64-musl": "16.2.12",
+        "@next/swc-linux-x64-gnu": "16.2.12",
+        "@next/swc-linux-x64-musl": "16.2.12",
+        "@next/swc-win32-arm64-msvc": "16.2.12",
+        "@next/swc-win32-x64-msvc": "16.2.12",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {

--- a/pages/api/hello.tsx
+++ b/pages/api/hello.tsx
@@ -1,6 +1,0 @@
-import { NextApiRequest, NextApiResponse } from 'next';
-
-export default (req: NextApiRequest, res: NextApiResponse) => {
-  res.statusCode = 200;
-  res.json({ name: 'John Doe' });
-};

--- a/tests/production-hygiene.spec.ts
+++ b/tests/production-hygiene.spec.ts
@@ -1,0 +1,15 @@
+import { expect, test } from '@playwright/test';
+
+test('the removed hello API returns not found', async ({ request }) => {
+  const response = await request.get('/api/hello');
+
+  expect(response.status()).toBe(404);
+});
+
+test('pages include the low-risk security headers', async ({ request }) => {
+  const response = await request.get('/');
+  const headers = response.headers();
+
+  expect(headers['x-content-type-options']).toBe('nosniff');
+  expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin');
+});


### PR DESCRIPTION
## Summary

- remove the unused /api/hello route and cover its 404 behavior
- add global X-Content-Type-Options and Referrer-Policy response headers
- migrate Playwright CI from Yarn to the committed npm lockfile and package script
- apply safe lockfile-only audit remediation

CSP was evaluated but intentionally deferred. The current Pages Router app uses inline scripts, Emotion styles, Next.js runtime scripts, Vercel Analytics, Google Tag Manager, an external Prism stylesheet, and external connections; a strict or incomplete policy could break rendering or analytics and needs a separate nonce/allowlist design.

## Verification

- npm run test:unit — 33/33 passed
- npm run build — passed with Next.js 16.2.12
- production-server Playwright run on isolated port 3103 with server reuse disabled and one worker — 26/26 passed
- focused production hygiene spec demonstrated red before implementation and green afterward — 2/2 passed
- Prettier check for every PR-authored source, workflow, test, spec, and plan file — passed
- git diff --check master..HEAD — passed

The repository-wide npm run format:check still reports 98 pre-existing formatting findings; this PR does not reformat unrelated files.

## Audit

A non-breaking npm audit fix reduced findings from 5 vulnerabilities (1 low, 4 high) to 3 high vulnerabilities and updated only package-lock.json. It patched transitive diff and js-yaml and advanced Next.js within the existing semver range from 16.2.11 to 16.2.12.

The remaining PostCSS and sharp advisories are transitive through Next.js. npm only offers npm audit fix --force, which proposes a breaking downgrade to Next.js 9.3.3, so that remediation was not applied.