### PR TITLE
Add crawler sitemap and robots guidance

### DIFF
--- a/docs/superpowers/plans/2026-07-27-robots-sitemap.md
+++ b/docs/superpowers/plans/2026-07-27-robots-sitemap.md
@@ -1,0 +1,204 @@
+# Robots and Sitemap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add crawler guidance and a deterministic XML sitemap containing the core public pages plus every project and book detail page.
+
+**Architecture:** A pure TypeScript module derives canonical URLs from the existing site configuration and Markdown content loader, then serializes escaped, sorted XML. A Pages Router response page serves that XML, while a static public file serves crawler rules.
+
+**Tech Stack:** Next.js 16 Pages Router, TypeScript, Node test runner through `tsx`, `fast-xml-parser`, and Playwright.
+
+## Global Constraints
+
+- Use the canonical `https://www.rylew.dev` origin already configured.
+- Include only `/`, `/about`, `/books`, `/projects`, and every project/book detail page.
+- Automatically include future project and book Markdown slugs.
+- Exclude all API, tag, and category taxonomy routes.
+- Serve well-formed, escaped, deduplicated, stable XML with `application/xml; charset=utf-8`.
+- Allow public crawling and reference the canonical sitemap without listing API routes in `robots.txt`.
+- Do not modify taxonomy generation, layout/page metadata, positioning copy, README, homepage, production headers/workflows, or content.
+
+---
+
+### Task 1: Specify the canonical URL set and XML serialization
+
+**Files:**
+
+- Create: `tests/sitemap.test.ts`
+- Create: `lib/sitemap.ts`
+- Modify: `package.json`
+- Modify: `package-lock.json`
+
+**Interfaces:**
+
+- Produces: `getCanonicalSitemapUrls(): string[]`
+- Produces: `generateSitemapXml(urls?: readonly string[]): string`
+
+- [ ] **Step 1: Install the XML validator used by tests**
+
+Run:
+
+```powershell
+npm install --save-dev fast-xml-parser
+```
+
+- [ ] **Step 2: Write the failing sitemap tests**
+
+Create `tests/sitemap.test.ts` with tests that:
+
+```typescript
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { XMLParser, XMLValidator } from 'fast-xml-parser';
+import { getContentList } from '../lib/content';
+import { generateSitemapXml, getCanonicalSitemapUrls } from '../lib/sitemap';
+
+const expectedUrls = [
+  'https://www.rylew.dev/',
+  'https://www.rylew.dev/about',
+  'https://www.rylew.dev/books',
+  'https://www.rylew.dev/projects',
+  ...getContentList('book').map(
+    ({ slug }) => `https://www.rylew.dev/books/${encodeURIComponent(slug!)}`
+  ),
+  ...getContentList('project').map(
+    ({ slug }) => `https://www.rylew.dev/projects/${encodeURIComponent(slug!)}`
+  ),
+].sort();
+
+test('generates valid XML with every canonical content URL', () => {
+  const xml = generateSitemapXml();
+  assert.equal(XMLValidator.validate(xml), true);
+  const parsed = new XMLParser().parse(xml);
+  const locations = parsed.urlset.url.map(({ loc }: { loc: string }) => loc);
+  assert.deepEqual(locations, expectedUrls);
+});
+```
+
+Add separate assertions for sorted, deduplicated, repeatable output,
+`& < > " '` escaping when explicit URLs are serialized, and absence of
+`/api/`, `/tags/`, and `/categories/`.
+
+- [ ] **Step 3: Verify RED**
+
+Run:
+
+```powershell
+npm run test:unit
+```
+
+Expected: failure because `lib/sitemap.ts` does not exist.
+
+- [ ] **Step 4: Implement the minimum generator**
+
+Create `lib/sitemap.ts` with:
+
+```typescript
+import SiteConfig from '../config/index.json';
+import { getContentList } from './content';
+
+const CORE_PATHS = ['/', '/about', '/books', '/projects'] as const;
+
+export const getCanonicalSitemapUrls = (): string[] => {
+  const detailPaths = (['book', 'project'] as const).flatMap((type) =>
+    getContentList(type).map(({ slug }) => {
+      if (typeof slug !== 'string' || slug.length === 0) {
+        throw new Error(`${type} content requires a slug`);
+      }
+      return `/${type}s/${encodeURIComponent(slug)}`;
+    })
+  );
+
+  return [
+    ...new Set(
+      [...CORE_PATHS, ...detailPaths].map(
+        (pathname) => new URL(pathname, SiteConfig.site.siteUrl).href
+      )
+    ),
+  ].sort();
+};
+```
+
+Add a private XML escape helper and implement `generateSitemapXml` with an XML
+declaration, the sitemap protocol namespace, one `<url><loc>escaped URL</loc></url>`
+per unique sorted URL, and a final newline.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run `npm run test:unit`; expected: all unit tests pass.
+
+### Task 2: Serve the crawler files
+
+**Files:**
+
+- Create: `pages/sitemap.xml.tsx`
+- Create: `public/robots.txt`
+- Create temporarily, then remove: `playwright.production.config.ts`
+- Create: `tests/crawler-files.spec.ts`
+
+**Interfaces:**
+
+- Consumes: `generateSitemapXml()` from `lib/sitemap.ts`
+- Produces: `GET /sitemap.xml` as `application/xml; charset=utf-8`
+- Produces: `GET /robots.txt` as plain text
+
+- [ ] **Step 1: Write the failing production endpoint tests**
+
+Create `tests/crawler-files.spec.ts` to request `/robots.txt` and
+`/sitemap.xml`. Assert HTTP 200, expected content types, `User-agent: *`,
+`Allow: /`, the absolute sitemap directive, valid XML, all expected canonical
+locations, and absence of API/tag/category routes.
+
+- [ ] **Step 2: Verify RED against a production server**
+
+Create a temporary `playwright.production.config.ts` that runs
+`npm run start -- -p 3105` with `baseURL` and `webServer.url` set to
+`http://127.0.0.1:3105`. Run:
+
+```powershell
+npm run build
+npx playwright test tests/crawler-files.spec.ts --config playwright.production.config.ts
+```
+
+Expected: endpoint tests fail with 404 responses.
+
+- [ ] **Step 3: Add the crawler endpoints**
+
+Create `pages/sitemap.xml.tsx` with a null-rendering component and a typed
+`getServerSideProps` that sets status 200, sets
+`Content-Type: application/xml; charset=utf-8`, and ends the response with
+`generateSitemapXml()`.
+
+Create `public/robots.txt` with:
+
+```text
+User-agent: *
+Allow: /
+
+Sitemap: https://www.rylew.dev/sitemap.xml
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Rebuild and rerun the focused production endpoint tests; expected: both pass.
+
+- [ ] **Step 5: Run full verification and remove temporary configuration**
+
+Run:
+
+```powershell
+npx prettier --check docs/superpowers/specs/2026-07-27-robots-sitemap-design.md docs/superpowers/plans/2026-07-27-robots-sitemap.md lib/sitemap.ts pages/sitemap.xml.tsx public/robots.txt tests/sitemap.test.ts tests/crawler-files.spec.ts package.json package-lock.json
+npm run test:unit
+npm run build
+npx playwright test --config playwright.production.config.ts
+```
+
+Remove `playwright.production.config.ts`, restore unrelated generated build
+drift, and confirm `git status --short` contains only intended files.
+
+- [ ] **Step 6: Review and publish**
+
+Review `git diff master...HEAD` plus the staged diff against this specification,
+commit the implementation, push `tier3/robots-sitemap`, and open a GitHub pull
+request targeting `master` with the verification commands and results. Do not
+merge the pull request.

--- a/docs/superpowers/plans/2026-07-27-robots-sitemap.md
+++ b/docs/superpowers/plans/2026-07-27-robots-sitemap.md
@@ -187,7 +187,7 @@ Rebuild and rerun the focused production endpoint tests; expected: both pass.
 Run:
 
 ```powershell
-npx prettier --check docs/superpowers/specs/2026-07-27-robots-sitemap-design.md docs/superpowers/plans/2026-07-27-robots-sitemap.md lib/sitemap.ts pages/sitemap.xml.tsx public/robots.txt tests/sitemap.test.ts tests/crawler-files.spec.ts package.json package-lock.json
+npx prettier --check --ignore-unknown docs/superpowers/specs/2026-07-27-robots-sitemap-design.md docs/superpowers/plans/2026-07-27-robots-sitemap.md lib/sitemap.ts pages/sitemap.xml.tsx public/robots.txt tests/sitemap.test.ts tests/crawler-files.spec.ts package.json package-lock.json
 npm run test:unit
 npm run build
 npx playwright test --config playwright.production.config.ts

--- a/docs/superpowers/specs/2026-07-27-robots-sitemap-design.md
+++ b/docs/superpowers/specs/2026-07-27-robots-sitemap-design.md
@@ -1,0 +1,57 @@
+# Robots and Sitemap Design
+
+## Goal
+
+Expose crawler guidance at `/robots.txt` and a deterministic XML sitemap at
+`/sitemap.xml` for the site's valuable canonical public pages.
+
+## Scope
+
+The sitemap contains exactly:
+
+- `https://www.rylew.dev/`
+- `https://www.rylew.dev/about`
+- `https://www.rylew.dev/books`
+- `https://www.rylew.dev/projects`
+- Every book detail URL derived from the Markdown frontmatter slug
+- Every project detail URL derived from the Markdown frontmatter slug
+
+It excludes every `/api/` URL and all `/books/tags/`, `/books/categories/`,
+and `/projects/tags/` taxonomy URLs. This work does not change taxonomy
+generation, page metadata, layout, copy, content, documentation outside these
+implementation records, headers, or deployment workflows.
+
+## Architecture
+
+`lib/sitemap.ts` owns the canonical URL list and XML serialization. It reads
+the existing `config/index.json` canonical origin and calls
+`getContentList("project")` and `getContentList("book")`, so adding a Markdown
+content file with a slug automatically adds its detail page. Slugs are encoded
+as URL path segments, URLs are sorted before serialization, and XML-reserved
+characters are escaped. Duplicate canonical URLs are emitted only once.
+
+`pages/sitemap.xml.tsx` follows the official Next.js Pages Router pattern: a
+`getServerSideProps` function writes the generated XML to the Node response,
+sets `application/xml; charset=utf-8`, and ends the response. The page component
+renders nothing.
+
+`public/robots.txt` allows crawling from the root and references the absolute
+canonical sitemap URL. It does not list API routes, either as crawl targets or
+as advertised disallow entries.
+
+## Error Handling and Stability
+
+Content entries without a non-empty slug fail sitemap generation instead of
+silently emitting an invalid canonical URL. The output omits volatile
+timestamps, deduplicates and sorts the complete URL set lexicographically, and
+ends with a newline, making identical content produce byte-for-byte stable XML.
+
+## Testing
+
+Unit tests parse and validate the XML, compare its locations with the complete
+expected set from repository content, assert stable ordering and repeated
+output, exercise XML escaping, and explicitly reject API and taxonomy URLs.
+
+Production-server Playwright coverage requests both endpoints on port 3105. It
+checks response status, content type, crawler rules, sitemap reference, XML
+parseability, expected canonical URLs, and the same explicit exclusions.

--- a/lib/sitemap.ts
+++ b/lib/sitemap.ts
@@ -1,0 +1,54 @@
+import SiteConfig from '../config/index.json';
+
+import { getContentList } from './content';
+
+const CORE_PATHS = ['/', '/about', '/books', '/projects'] as const;
+
+const escapeXml = (value: string): string =>
+  value.replace(
+    /[&<>"']/g,
+    (character) =>
+      ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        '"': '&quot;',
+        "'": '&apos;',
+      })[character]!
+  );
+
+export const getCanonicalSitemapUrls = (): string[] => {
+  const detailPaths = (['book', 'project'] as const).flatMap((contentType) =>
+    getContentList(contentType).map(({ slug }) => {
+      if (typeof slug !== 'string' || slug.trim().length === 0) {
+        throw new Error(`${contentType} content requires a slug`);
+      }
+
+      return `/${contentType}s/${encodeURIComponent(slug)}`;
+    })
+  );
+
+  return [
+    ...new Set(
+      [...CORE_PATHS, ...detailPaths].map(
+        (pathname) => new URL(pathname, SiteConfig.site.siteUrl).href
+      )
+    ),
+  ].sort();
+};
+
+export const generateSitemapXml = (
+  urls: readonly string[] = getCanonicalSitemapUrls()
+): string => {
+  const entries = [...new Set(urls)]
+    .sort()
+    .map((url) => `  <url>\n    <loc>${escapeXml(url)}</loc>\n  </url>`);
+
+  return [
+    '<?xml version="1.0" encoding="UTF-8"?>',
+    '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">',
+    ...entries,
+    '</urlset>',
+    '',
+  ].join('\n');
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
         "@types/node": "^26.1.1",
         "@types/react": "^19.2.17",
         "@types/remark-prism": "^1.3.7",
+        "fast-xml-parser": "^5.10.1",
         "playwright": "^1.58.2",
         "prettier": "^3.9.5",
         "tsx": "^4.23.1",
@@ -1559,6 +1560,19 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@playwright/test": {
       "version": "1.61.1",
       "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
@@ -2442,6 +2456,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2786,6 +2813,47 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-xml-builder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+      "integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.6.2",
+        "xml-naming": "^0.3.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^3.0.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^2.0.0",
+        "path-expression-matcher": "^1.6.2",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.3.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/find-root": {
@@ -3135,6 +3203,19 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+      "integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -4166,6 +4247,22 @@
       "integrity": "sha512-twN+njEipszzlMJd4ONUYgSfZPDxgHhT9Ahed5uTigpQn90FggW4SA/AIPq/6a149fTbE9qBEcSwE3FAEp6wQQ==",
       "license": "ISC"
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+      "integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -4657,6 +4754,22 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
+      }
+    },
     "node_modules/styled-jsx": {
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
@@ -5040,6 +5153,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+      "integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/remark-prism": "^1.3.7",
+    "fast-xml-parser": "^5.10.1",
     "playwright": "^1.58.2",
     "prettier": "^3.9.5",
     "tsx": "^4.23.1",

--- a/pages/sitemap.xml.tsx
+++ b/pages/sitemap.xml.tsx
@@ -1,0 +1,17 @@
+import type { GetServerSideProps } from 'next';
+
+import { generateSitemapXml } from '../lib/sitemap';
+
+const SitemapXml = () => null;
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  res.statusCode = 200;
+  res.setHeader('Content-Type', 'application/xml; charset=utf-8');
+  res.end(generateSitemapXml());
+
+  return {
+    props: {},
+  };
+};
+
+export default SitemapXml;

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.rylew.dev/sitemap.xml

--- a/tests/crawler-files.spec.ts
+++ b/tests/crawler-files.spec.ts
@@ -4,18 +4,21 @@ import { XMLParser, XMLValidator } from 'fast-xml-parser';
 import { getContentList } from '../lib/content';
 
 const CANONICAL_ORIGIN = 'https://www.rylew.dev';
+const SITEMAP_NAMESPACE = 'http://www.sitemaps.org/schemas/sitemap/0.9';
 
 const expectedSitemapUrls = [
-  `${CANONICAL_ORIGIN}/`,
-  `${CANONICAL_ORIGIN}/about`,
-  `${CANONICAL_ORIGIN}/books`,
-  `${CANONICAL_ORIGIN}/projects`,
-  ...getContentList('book').map(
-    ({ slug }) => `${CANONICAL_ORIGIN}/books/${encodeURIComponent(slug!)}`
-  ),
-  ...getContentList('project').map(
-    ({ slug }) => `${CANONICAL_ORIGIN}/projects/${encodeURIComponent(slug!)}`
-  ),
+  ...new Set([
+    `${CANONICAL_ORIGIN}/`,
+    `${CANONICAL_ORIGIN}/about`,
+    `${CANONICAL_ORIGIN}/books`,
+    `${CANONICAL_ORIGIN}/projects`,
+    ...getContentList('book').map(
+      ({ slug }) => `${CANONICAL_ORIGIN}/books/${encodeURIComponent(slug!)}`
+    ),
+    ...getContentList('project').map(
+      ({ slug }) => `${CANONICAL_ORIGIN}/projects/${encodeURIComponent(slug!)}`
+    ),
+  ]),
 ].sort();
 
 test('robots.txt allows public crawling and points to the canonical sitemap', async ({
@@ -26,10 +29,11 @@ test('robots.txt allows public crawling and points to the canonical sitemap', as
   expect(response.status()).toBe(200);
   expect(response.headers()['content-type']).toMatch(/^text\/plain\b/i);
 
-  const body = await response.text();
-  expect(body).toContain('User-agent: *');
-  expect(body).toContain('Allow: /');
-  expect(body).toContain(`Sitemap: ${CANONICAL_ORIGIN}/sitemap.xml`);
+  const body = (await response.text()).replace(/\r\n/g, '\n').trimEnd();
+  expect(body).toBe(`User-agent: *
+Allow: /
+
+Sitemap: ${CANONICAL_ORIGIN}/sitemap.xml`);
   expect(body).not.toContain('/api');
 });
 
@@ -46,11 +50,15 @@ test('sitemap.xml serves valid canonical URLs and excludes low-value routes', as
   const xml = await response.text();
   expect(XMLValidator.validate(xml)).toBe(true);
 
-  const parsed = new XMLParser().parse(xml) as {
-    urlset: { url: Array<{ loc: string }> };
+  const parsed = new XMLParser({ ignoreAttributes: false }).parse(xml) as {
+    urlset: {
+      '@_xmlns': string;
+      url: Array<{ loc: string }>;
+    };
   };
   const locations = parsed.urlset.url.map(({ loc }) => loc);
 
+  expect(parsed.urlset['@_xmlns']).toBe(SITEMAP_NAMESPACE);
   expect(locations).toEqual(expectedSitemapUrls);
 
   for (const excludedSegment of ['/api/', '/tags/', '/categories/']) {

--- a/tests/crawler-files.spec.ts
+++ b/tests/crawler-files.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test';
+import { XMLParser, XMLValidator } from 'fast-xml-parser';
+
+import { getContentList } from '../lib/content';
+
+const CANONICAL_ORIGIN = 'https://www.rylew.dev';
+
+const expectedSitemapUrls = [
+  `${CANONICAL_ORIGIN}/`,
+  `${CANONICAL_ORIGIN}/about`,
+  `${CANONICAL_ORIGIN}/books`,
+  `${CANONICAL_ORIGIN}/projects`,
+  ...getContentList('book').map(
+    ({ slug }) => `${CANONICAL_ORIGIN}/books/${encodeURIComponent(slug!)}`
+  ),
+  ...getContentList('project').map(
+    ({ slug }) => `${CANONICAL_ORIGIN}/projects/${encodeURIComponent(slug!)}`
+  ),
+].sort();
+
+test('robots.txt allows public crawling and points to the canonical sitemap', async ({
+  request,
+}) => {
+  const response = await request.get('/robots.txt');
+
+  expect(response.status()).toBe(200);
+  expect(response.headers()['content-type']).toMatch(/^text\/plain\b/i);
+
+  const body = await response.text();
+  expect(body).toContain('User-agent: *');
+  expect(body).toContain('Allow: /');
+  expect(body).toContain(`Sitemap: ${CANONICAL_ORIGIN}/sitemap.xml`);
+  expect(body).not.toContain('/api');
+});
+
+test('sitemap.xml serves valid canonical URLs and excludes low-value routes', async ({
+  request,
+}) => {
+  const response = await request.get('/sitemap.xml');
+
+  expect(response.status()).toBe(200);
+  expect(response.headers()['content-type']).toMatch(
+    /^application\/xml;\s*charset=utf-8$/i
+  );
+
+  const xml = await response.text();
+  expect(XMLValidator.validate(xml)).toBe(true);
+
+  const parsed = new XMLParser().parse(xml) as {
+    urlset: { url: Array<{ loc: string }> };
+  };
+  const locations = parsed.urlset.url.map(({ loc }) => loc);
+
+  expect(locations).toEqual(expectedSitemapUrls);
+
+  for (const excludedSegment of ['/api/', '/tags/', '/categories/']) {
+    expect(
+      locations.some((location) => location.includes(excludedSegment))
+    ).toBe(false);
+  }
+});

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -7,33 +7,40 @@ import { getContentList } from '../lib/content';
 import { generateSitemapXml, getCanonicalSitemapUrls } from '../lib/sitemap';
 
 const CANONICAL_ORIGIN = 'https://www.rylew.dev';
+const SITEMAP_NAMESPACE = 'http://www.sitemaps.org/schemas/sitemap/0.9';
 
 const expectedUrls = [
-  `${CANONICAL_ORIGIN}/`,
-  `${CANONICAL_ORIGIN}/about`,
-  `${CANONICAL_ORIGIN}/books`,
-  `${CANONICAL_ORIGIN}/projects`,
-  ...getContentList('book').map(
-    ({ slug }) => `${CANONICAL_ORIGIN}/books/${encodeURIComponent(slug!)}`
-  ),
-  ...getContentList('project').map(
-    ({ slug }) => `${CANONICAL_ORIGIN}/projects/${encodeURIComponent(slug!)}`
-  ),
+  ...new Set([
+    `${CANONICAL_ORIGIN}/`,
+    `${CANONICAL_ORIGIN}/about`,
+    `${CANONICAL_ORIGIN}/books`,
+    `${CANONICAL_ORIGIN}/projects`,
+    ...getContentList('book').map(
+      ({ slug }) => `${CANONICAL_ORIGIN}/books/${encodeURIComponent(slug!)}`
+    ),
+    ...getContentList('project').map(
+      ({ slug }) => `${CANONICAL_ORIGIN}/projects/${encodeURIComponent(slug!)}`
+    ),
+  ]),
 ].sort();
 
-const parseLocations = (xml: string): string[] => {
-  const parsed = new XMLParser().parse(xml) as {
-    urlset: { url: Array<{ loc: string }> };
+const parseSitemap = (xml: string) => {
+  return new XMLParser({ ignoreAttributes: false }).parse(xml) as {
+    urlset: {
+      '@_xmlns': string;
+      url: Array<{ loc: string }>;
+    };
   };
-
-  return parsed.urlset.url.map(({ loc }) => loc);
 };
 
 test('generates valid XML with every canonical content URL', () => {
   const xml = generateSitemapXml();
+  const sitemap = parseSitemap(xml);
+  const locations = sitemap.urlset.url.map(({ loc }) => loc);
 
   assert.equal(XMLValidator.validate(xml), true);
-  assert.deepEqual(parseLocations(xml), expectedUrls);
+  assert.equal(sitemap.urlset['@_xmlns'], SITEMAP_NAMESPACE);
+  assert.deepEqual(locations, expectedUrls);
   assert.deepEqual(getCanonicalSitemapUrls(), expectedUrls);
 });
 
@@ -48,10 +55,10 @@ test('sorts and deduplicates URLs for stable sitemap output', () => {
   const second = generateSitemapXml([...urls].reverse());
 
   assert.equal(first, second);
-  assert.deepEqual(parseLocations(first), [
-    `${CANONICAL_ORIGIN}/about`,
-    `${CANONICAL_ORIGIN}/projects/z-last`,
-  ]);
+  assert.deepEqual(
+    parseSitemap(first).urlset.url.map(({ loc }) => loc),
+    [`${CANONICAL_ORIGIN}/about`, `${CANONICAL_ORIGIN}/projects/z-last`]
+  );
   assert.ok(first.endsWith('\n'));
 });
 

--- a/tests/sitemap.test.ts
+++ b/tests/sitemap.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { XMLParser, XMLValidator } from 'fast-xml-parser';
+
+import { getContentList } from '../lib/content';
+import { generateSitemapXml, getCanonicalSitemapUrls } from '../lib/sitemap';
+
+const CANONICAL_ORIGIN = 'https://www.rylew.dev';
+
+const expectedUrls = [
+  `${CANONICAL_ORIGIN}/`,
+  `${CANONICAL_ORIGIN}/about`,
+  `${CANONICAL_ORIGIN}/books`,
+  `${CANONICAL_ORIGIN}/projects`,
+  ...getContentList('book').map(
+    ({ slug }) => `${CANONICAL_ORIGIN}/books/${encodeURIComponent(slug!)}`
+  ),
+  ...getContentList('project').map(
+    ({ slug }) => `${CANONICAL_ORIGIN}/projects/${encodeURIComponent(slug!)}`
+  ),
+].sort();
+
+const parseLocations = (xml: string): string[] => {
+  const parsed = new XMLParser().parse(xml) as {
+    urlset: { url: Array<{ loc: string }> };
+  };
+
+  return parsed.urlset.url.map(({ loc }) => loc);
+};
+
+test('generates valid XML with every canonical content URL', () => {
+  const xml = generateSitemapXml();
+
+  assert.equal(XMLValidator.validate(xml), true);
+  assert.deepEqual(parseLocations(xml), expectedUrls);
+  assert.deepEqual(getCanonicalSitemapUrls(), expectedUrls);
+});
+
+test('sorts and deduplicates URLs for stable sitemap output', () => {
+  const urls = [
+    `${CANONICAL_ORIGIN}/projects/z-last`,
+    `${CANONICAL_ORIGIN}/about`,
+    `${CANONICAL_ORIGIN}/projects/z-last`,
+  ];
+
+  const first = generateSitemapXml(urls);
+  const second = generateSitemapXml([...urls].reverse());
+
+  assert.equal(first, second);
+  assert.deepEqual(parseLocations(first), [
+    `${CANONICAL_ORIGIN}/about`,
+    `${CANONICAL_ORIGIN}/projects/z-last`,
+  ]);
+  assert.ok(first.endsWith('\n'));
+});
+
+test('escapes XML-reserved characters in locations', () => {
+  const xml = generateSitemapXml([`${CANONICAL_ORIGIN}/search?a=1&b=<two>"'`]);
+
+  assert.equal(XMLValidator.validate(xml), true);
+  assert.match(
+    xml,
+    /<loc>https:\/\/www\.rylew\.dev\/search\?a=1&amp;b=&lt;two&gt;&quot;&apos;<\/loc>/
+  );
+});
+
+test('excludes API and taxonomy routes from the canonical URL set', () => {
+  const urls = getCanonicalSitemapUrls();
+
+  for (const excludedSegment of ['/api/', '/tags/', '/categories/']) {
+    assert.equal(
+      urls.some((url) => url.includes(excludedSegment)),
+      false,
+      `unexpected sitemap URL containing ${excludedSegment}`
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- serve a deterministic XML sitemap from the canonical `https://www.rylew.dev` origin
- automatically include every project and book Markdown slug alongside the four core public pages
- add crawler guidance that references the sitemap without advertising API routes
- validate XML, escaping, stable ordering, content types, and explicit API/taxonomy exclusions

## Test evidence

- `npx prettier --check --ignore-unknown ...` — passed for every changed file
- `npm run test:unit` — 37 passed
- `npm run build` — passed (Next.js production build)
- `npx playwright test --config playwright.production.config.ts` — 26 passed against `next start` on port 3105; temporary config removed