### PR TITLE
Add page-specific canonical and social metadata

### DIFF
--- a/components/layout.tsx
+++ b/components/layout.tsx
@@ -11,9 +11,10 @@ import { ChatWidget } from './chat';
 
 interface ILayout {
   children: ReactNode;
-  pathname: string;
+  canonicalPath: string;
   pageTitle: string;
   pageDescription?: string;
+  ogType?: 'website' | 'article';
 }
 
 interface MenuContextType {
@@ -40,12 +41,23 @@ export const ThemeContext = createContext<ThemeContextType>({
 
 const Layout = ({
   children,
-  pathname,
+  canonicalPath,
   pageTitle,
   pageDescription,
+  ogType = 'website',
 }: ILayout) => {
   const [menuOpen, setMenuOpen] = useState(false);
   const [theme, setTheme] = useState<ThemeMode>('light');
+  const canonicalUrl = new URL(canonicalPath, SiteConfig.site.siteUrl);
+  canonicalUrl.search = '';
+  canonicalUrl.hash = '';
+
+  const canonicalHref = canonicalUrl.toString();
+  const description = pageDescription || SiteConfig.site.siteDescription;
+  const socialImage = new URL(
+    SiteConfig.site.siteImage,
+    SiteConfig.site.siteUrl
+  ).toString();
 
   const toggleMenuOpen = () => {
     menuOpen ? setMenuOpen(false) : setMenuOpen(true);
@@ -55,14 +67,18 @@ const Layout = ({
     setTheme((current) => {
       const next = current === 'dark' ? 'light' : 'dark';
       document.documentElement.dataset.theme = next;
-      try { window.localStorage.setItem('theme', next); } catch {}
+      try {
+        window.localStorage.setItem('theme', next);
+      } catch {}
       return next;
     });
   };
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const storedTheme = window.localStorage.getItem('theme') as ThemeMode | null;
+    const storedTheme = window.localStorage.getItem(
+      'theme'
+    ) as ThemeMode | null;
     const prefersDark =
       window.matchMedia &&
       window.matchMedia('(prefers-color-scheme: dark)').matches;
@@ -75,7 +91,7 @@ const Layout = ({
     document.querySelectorAll('pre').forEach((node) => {
       node.setAttribute('tabindex', '0');
     });
-  }, [pathname]);
+  }, [canonicalPath]);
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>
@@ -91,30 +107,15 @@ const Layout = ({
             content={SiteConfig.site.keywords}
             key="keywords"
           />
-          <meta
-            name="description"
-            key="description"
-            content={pageDescription || SiteConfig.site.siteDescription}
-          />
+          <meta name="description" key="description" content={description} />
+          <link rel="canonical" href={canonicalHref} key="canonical" />
 
           {/* og tags */}
           <meta property="og:title" content={pageTitle} key="ogtitle" />
-          <meta
-            property="og:description"
-            content={pageDescription || SiteConfig.site.siteDescription}
-            key="ogdesc"
-          />
-          <meta
-            property="og:url"
-            content={SiteConfig.site.siteUrl}
-            key="ogurl"
-          />
-          <meta property="og:type" content="website" key="ogtype" />
-          <meta
-            property="og:image"
-            content={`${SiteConfig.site.siteUrl}${SiteConfig.site.siteImage}`}
-            key="ogimage"
-          />
+          <meta property="og:description" content={description} key="ogdesc" />
+          <meta property="og:url" content={canonicalHref} key="ogurl" />
+          <meta property="og:type" content={ogType} key="ogtype" />
+          <meta property="og:image" content={socialImage} key="ogimage" />
           <meta
             property="og:site_name"
             content={SiteConfig.site.siteName}
@@ -128,6 +129,13 @@ const Layout = ({
             content={SiteConfig.author.twitterHandle}
             key="twhandle"
           />
+          <meta name="twitter:title" content={pageTitle} key="twtitle" />
+          <meta
+            name="twitter:description"
+            content={description}
+            key="twdescription"
+          />
+          <meta name="twitter:image" content={socialImage} key="twimage" />
 
           <link rel="shortcut icon" href="/favicon.ico" />
         </Head>
@@ -135,7 +143,7 @@ const Layout = ({
           Skip to content
         </a>
         <Nav />
-        <Header pathname={pathname} title={pageTitle} />
+        <Header pathname={canonicalPath} title={pageTitle} />
         {/* tabIndex lets the skip link actually move focus here, not just
             scroll. main:focus drops the ring -- see layout.css. */}
         <StyledMain id="main" tabIndex={-1}>

--- a/docs/superpowers/plans/2026-07-27-page-metadata.md
+++ b/docs/superpowers/plans/2026-07-27-page-metadata.md
@@ -45,7 +45,7 @@ const expectUniqueMeta = async (
 ) => {
   const metadata = page.locator(selector);
   await expect(metadata).toHaveCount(1);
-  await expect(metadata).toHaveAttribute("content", expectedContent);
+  await expect(metadata).toHaveAttribute('content', expectedContent);
 };
 ```
 
@@ -53,12 +53,12 @@ For every fixture assert:
 
 ```ts
 await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
-  "href",
+  'href',
   expectedUrl
 );
 await expectUniqueMeta(page, 'meta[property="og:url"]', expectedUrl);
 await expectUniqueMeta(page, 'meta[property="og:type"]', expectedType);
-await expectUniqueMeta(page, 'meta[name="twitter:card"]', "summary");
+await expectUniqueMeta(page, 'meta[name="twitter:card"]', 'summary');
 await expectUniqueMeta(page, 'meta[name="twitter:title"]', expectedTitle);
 await expectUniqueMeta(
   page,
@@ -68,7 +68,7 @@ await expectUniqueMeta(
 await expectUniqueMeta(
   page,
   'meta[name="twitter:image"]',
-  "https://www.rylew.dev/Logo.png"
+  'https://www.rylew.dev/Logo.png'
 );
 ```
 
@@ -138,8 +138,8 @@ Resolve the path against the configured origin and remove query/hash data:
 
 ```ts
 const canonicalUrl = new URL(canonicalPath, SiteConfig.site.siteUrl);
-canonicalUrl.search = "";
-canonicalUrl.hash = "";
+canonicalUrl.search = '';
+canonicalUrl.hash = '';
 
 const canonicalHref = canonicalUrl.toString();
 const description = pageDescription || SiteConfig.site.siteDescription;

--- a/docs/superpowers/plans/2026-07-27-page-metadata.md
+++ b/docs/superpowers/plans/2026-07-27-page-metadata.md
@@ -1,0 +1,329 @@
+# Page-Specific Canonical and Social Metadata Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Emit correct, unique canonical, Open Graph, and Twitter metadata for every rendered page.
+
+**Architecture:** Make each page pass its concrete public path to `Layout` through a required `canonicalPath` prop. `Layout` will sanitize and resolve that path against the configured site origin, emit the shared metadata, and default Open Graph type to `website`; only project and book details will request `article`.
+
+**Tech Stack:** Next.js 16 Pages Router, React 19, TypeScript, `next/head`, Playwright
+
+## Global Constraints
+
+- Use the configured canonical origin `https://www.rylew.dev`.
+- Never emit dynamic route placeholders such as `[id]`, `[tag]`, or `[category]`.
+- Exclude query strings and hashes from canonical URLs and `og:url`.
+- Reuse existing page title, description, and site-wide social image values.
+- Do not change positioning copy, keywords, the social image asset, content, taxonomy, sitemap/robots, README, homepage layout, workflows, dependencies, security headers, or structured data.
+- Use a temporary branch-local Playwright config on port 3106 and remove it before committing implementation.
+
+---
+
+### Task 1: Add focused metadata regression coverage
+
+**Files:**
+
+- Create: `tests/page-metadata.spec.ts`
+
+**Interfaces:**
+
+- Consumes: rendered `<head>` output for each public route
+- Produces: Playwright assertions for one canonical link, matching Open Graph URL/type, and complete Twitter card metadata
+
+- [ ] **Step 1: Write the failing metadata test**
+
+Create literal fixtures covering `/`, `/about`, `/projects`, `/books`,
+`/projects/cardgame`, `/books/accelerate`, one project tag, one book tag, and
+one book category. Use a helper that asserts each selector has count `1` before
+checking its literal content:
+
+```ts
+const expectUniqueMeta = async (
+  page: Page,
+  selector: string,
+  expectedContent: string
+) => {
+  const metadata = page.locator(selector);
+  await expect(metadata).toHaveCount(1);
+  await expect(metadata).toHaveAttribute("content", expectedContent);
+};
+```
+
+For every fixture assert:
+
+```ts
+await expect(page.locator('link[rel="canonical"]')).toHaveAttribute(
+  "href",
+  expectedUrl
+);
+await expectUniqueMeta(page, 'meta[property="og:url"]', expectedUrl);
+await expectUniqueMeta(page, 'meta[property="og:type"]', expectedType);
+await expectUniqueMeta(page, 'meta[name="twitter:card"]', "summary");
+await expectUniqueMeta(page, 'meta[name="twitter:title"]', expectedTitle);
+await expectUniqueMeta(
+  page,
+  'meta[name="twitter:description"]',
+  expectedDescription
+);
+await expectUniqueMeta(
+  page,
+  'meta[name="twitter:image"]',
+  "https://www.rylew.dev/Logo.png"
+);
+```
+
+Add a query/hash case for `/projects?utm_source=metadata#selected-work` that
+expects `https://www.rylew.dev/projects`.
+
+- [ ] **Step 2: Run the focused test to verify RED**
+
+Run:
+
+```powershell
+npx playwright test --config=playwright.metadata.config.ts tests/page-metadata.spec.ts --workers=1
+```
+
+Expected: FAIL because canonical links and Twitter title, description, and
+image tags do not exist, and detail `og:url` values still use the site root.
+
+- [ ] **Step 3: Confirm the failure is behavioral**
+
+Check that Playwright reached the real pages and failures point to missing or
+incorrect metadata selectors/values, not server startup, imports, or fixture
+typos.
+
+### Task 2: Centralize canonical and social metadata in Layout
+
+**Files:**
+
+- Modify: `components/layout.tsx`
+- Modify: `pages/index.tsx`
+- Modify: `pages/about.tsx`
+- Modify: `pages/projects.tsx`
+- Modify: `pages/books.tsx`
+
+**Interfaces:**
+
+- Consumes: `canonicalPath: string`, `pageTitle: string`,
+  `pageDescription?: string`, and `ogType?: "website" | "article"`
+- Produces: one sanitized absolute canonical URL, matching `og:url`, the
+  selected `og:type`, and complete Twitter metadata
+
+- [ ] **Step 1: Change the Layout contract**
+
+Replace `pathname` with required `canonicalPath`, add the optional `ogType`,
+and default it:
+
+```ts
+interface ILayout {
+  children: ReactNode;
+  canonicalPath: string;
+  pageTitle: string;
+  pageDescription?: string;
+  ogType?: "website" | "article";
+}
+
+const Layout = ({
+  children,
+  canonicalPath,
+  pageTitle,
+  pageDescription,
+  ogType = "website",
+}: ILayout) => {
+```
+
+- [ ] **Step 2: Derive shared metadata values**
+
+Resolve the path against the configured origin and remove query/hash data:
+
+```ts
+const canonicalUrl = new URL(canonicalPath, SiteConfig.site.siteUrl);
+canonicalUrl.search = "";
+canonicalUrl.hash = "";
+
+const canonicalHref = canonicalUrl.toString();
+const description = pageDescription || SiteConfig.site.siteDescription;
+const socialImage = new URL(
+  SiteConfig.site.siteImage,
+  SiteConfig.site.siteUrl
+).toString();
+```
+
+- [ ] **Step 3: Emit the complete metadata set**
+
+Add a keyed canonical link, use the shared values for existing Open Graph
+tags, and add Twitter title, description, and image:
+
+```tsx
+<link rel="canonical" href={canonicalHref} key="canonical" />
+<meta property="og:url" content={canonicalHref} key="ogurl" />
+<meta property="og:type" content={ogType} key="ogtype" />
+<meta name="twitter:title" content={pageTitle} key="twtitle" />
+<meta name="twitter:description" content={description} key="twdescription" />
+<meta name="twitter:image" content={socialImage} key="twimage" />
+```
+
+Use `canonicalPath` where `pathname` previously controlled the header and
+page-change effect.
+
+- [ ] **Step 4: Update static page callers**
+
+Pass `canonicalPath="/"`, `canonicalPath="/about"`,
+`canonicalPath="/projects"`, and `canonicalPath="/books"` from the respective
+pages without changing titles, descriptions, or visible content.
+
+- [ ] **Step 5: Run static metadata cases**
+
+Run:
+
+```powershell
+npx playwright test --config=playwright.metadata.config.ts tests/page-metadata.spec.ts --grep "homepage|static|query" --workers=1
+```
+
+Expected: PASS for static/query cases while dynamic fixtures remain to be
+implemented.
+
+### Task 3: Supply concrete dynamic canonical paths
+
+**Files:**
+
+- Modify: `pages/projects/[id].tsx`
+- Modify: `pages/books/[id].tsx`
+- Modify: `pages/projects/tags/[tag].tsx`
+- Modify: `pages/books/tags/[tag].tsx`
+- Modify: `pages/books/categories/[category].tsx`
+
+**Interfaces:**
+
+- Consumes: content `id` values and `getStaticProps` route parameters
+- Produces: URL-encoded concrete `canonicalPath` values; detail pages also
+  supply `ogType="article"`
+
+- [ ] **Step 1: Update project and book details**
+
+Remove `useRouter` and pass concrete content identifiers:
+
+```tsx
+<Layout
+  canonicalPath={`/projects/${encodeURIComponent(projectData.id)}`}
+  pageTitle={title}
+  pageDescription={description}
+  ogType="article"
+>
+```
+
+Use the equivalent `/books/${encodeURIComponent(bookData.id)}` path for book
+details.
+
+- [ ] **Step 2: Update project and book tag pages**
+
+Add `tag: string` to each page prop interface, return `tag: params?.tag as
+string` from `getStaticProps`, remove `useRouter`, and pass:
+
+```tsx
+canonicalPath={`/projects/tags/${encodeURIComponent(tag)}`}
+```
+
+Use the equivalent `/books/tags/` prefix on book tag pages.
+
+- [ ] **Step 3: Update the book category page**
+
+Add `category: string` to page props, return it from `getStaticProps`, remove
+`useRouter`, and pass:
+
+```tsx
+canonicalPath={`/books/categories/${encodeURIComponent(category)}`}
+```
+
+- [ ] **Step 4: Run the complete focused suite to verify GREEN**
+
+Run:
+
+```powershell
+npx playwright test --config=playwright.metadata.config.ts tests/page-metadata.spec.ts --workers=1
+```
+
+Expected: all metadata fixtures pass.
+
+- [ ] **Step 5: Refactor and re-run focused coverage**
+
+Remove duplicated value construction or obsolete router imports only where the
+new contract makes them unnecessary, then rerun the focused suite and confirm
+it remains green.
+
+### Task 4: Verify, review, and prepare the PR
+
+**Files:**
+
+- Modify temporarily, then remove: `playwright.metadata.config.ts`
+- Review: every file changed from `master`
+
+**Interfaces:**
+
+- Consumes: completed source and tests
+- Produces: a clean, verified branch and PR targeting `master`
+
+- [ ] **Step 1: Run changed-file formatting checks**
+
+Run Prettier against the changed TypeScript, test, and Markdown files:
+
+```powershell
+npx prettier --check components/layout.tsx pages/index.tsx pages/about.tsx pages/projects.tsx pages/books.tsx 'pages/projects/[id].tsx' 'pages/books/[id].tsx' 'pages/projects/tags/[tag].tsx' 'pages/books/tags/[tag].tsx' 'pages/books/categories/[category].tsx' tests/page-metadata.spec.ts docs/superpowers/specs/2026-07-27-page-metadata-design.md docs/superpowers/plans/2026-07-27-page-metadata.md
+```
+
+Expected: all matched files use Prettier formatting.
+
+- [ ] **Step 2: Run unit tests and production build**
+
+Run:
+
+```powershell
+npm run test:unit
+npm run build
+```
+
+Expected: 33 unit tests pass and the production build completes.
+
+- [ ] **Step 3: Switch the temporary Playwright config to production**
+
+Set its server command to `npm run start -- -p 3106`, keep its base URL on
+port 3106, and disable server reuse.
+
+- [ ] **Step 4: Run focused and full production-server Playwright coverage**
+
+Run:
+
+```powershell
+npx playwright test --config=playwright.metadata.config.ts tests/page-metadata.spec.ts --workers=1
+npx playwright test --config=playwright.metadata.config.ts --workers=1
+```
+
+Expected: the focused metadata suite and all existing browser tests pass
+against the production build.
+
+- [ ] **Step 5: Remove temporary/generated artifacts**
+
+Delete `playwright.metadata.config.ts`, restore unrelated generated
+`next-env.d.ts`, `tsconfig.json`, `me/summary.txt`, and
+`me/chat-context.json` drift if present, and confirm `git status --short`
+contains only intended files.
+
+- [ ] **Step 6: Self-review against the approved scope**
+
+Run:
+
+```powershell
+git diff --check master...HEAD
+git diff --stat master...HEAD
+git diff master...HEAD
+```
+
+Verify each route family has a concrete canonical path, detail pages alone use
+`article`, no literal route placeholders can reach metadata, all metadata is
+unique, and excluded files/behavior remain untouched.
+
+- [ ] **Step 7: Commit, push, and create the PR**
+
+Commit the implementation and tests, push `tier3/page-metadata`, and use the
+GitHub CLI to create a PR targeting `master` with the test evidence. Do not
+merge it.

--- a/docs/superpowers/specs/2026-07-27-page-metadata-design.md
+++ b/docs/superpowers/specs/2026-07-27-page-metadata-design.md
@@ -1,0 +1,71 @@
+# Page-Specific Canonical and Social Metadata Design
+
+## Goal
+
+Every rendered page must publish one absolute canonical URL and a matching
+`og:url` for its real route. Project and book detail pages must publish
+`og:type=article`; every other page must publish `og:type=website`. Twitter
+cards must reuse the page's existing title, description, and site-wide social
+image values.
+
+## Layout interface
+
+`Layout` will require a `canonicalPath` prop and accept an optional
+`ogType: "website" | "article"` prop that defaults to `"website"`.
+`canonicalPath` will also replace the existing `pathname` prop for header
+selection and page-change effects, so each caller provides one unambiguous,
+route-specific path.
+
+`Layout` will construct the absolute URL against the configured
+`https://www.rylew.dev` origin. It will remove any search parameters or hash
+before emitting metadata, ensuring tracked or anchored visits retain the same
+canonical URL.
+
+Static pages will pass literal paths. Dynamic pages will build concrete paths
+from build-time content or route parameters:
+
+- project detail: `/projects/${projectData.id}`
+- book detail: `/books/${bookData.id}`
+- project tag: `/projects/tags/${tag}`
+- book tag: `/books/tags/${tag}`
+- book category: `/books/categories/${category}`
+
+Dynamic segments will be URL-encoded before interpolation. No caller will use
+the Pages Router's `pathname`, because it represents route files such as
+`/projects/[id]`, not the public URL. This follows the current official
+Next.js Pages Router documentation.
+
+## Emitted metadata
+
+`Layout` will emit these values from its existing inputs and configuration:
+
+- `<link rel="canonical">` and `og:url`: the sanitized absolute canonical URL
+- `og:type`: the caller-supplied type, defaulting to `website`
+- `twitter:card`: the existing `summary` value
+- `twitter:title`: `pageTitle`
+- `twitter:description`: `pageDescription` or the existing site description
+- `twitter:image`: the same existing absolute image URL used by `og:image`
+
+Existing document-title formatting, descriptions, keywords, Open Graph image,
+site name, Twitter creator, favicon, visible content, and layout remain
+unchanged.
+
+## Verification
+
+A focused Playwright suite will cover the homepage, all static page families,
+at least one project detail, at least one book detail, and representative tag
+and category routes. It will assert that canonical, `og:url`, `og:type`, and
+each Twitter metadata tag occurs exactly once with the expected value. It will
+also load a route with a query string and hash and assert that neither appears
+in canonical metadata.
+
+The final verification will use a production build and production Next.js
+server on port 3106. Unit tests, changed-file formatting checks, the build, the
+focused metadata suite, and the full Playwright suite must pass before the PR
+is opened.
+
+## Non-goals
+
+This change will not alter positioning copy, keywords, the social image asset,
+content, taxonomy, sitemap or robots behavior, README, homepage layout,
+workflows, dependencies, security headers, or structured data.

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -25,7 +25,7 @@ const About = () => {
 
   return (
     <Layout
-      pathname={'/about'}
+      canonicalPath="/about"
       pageTitle="About"
       pageDescription={`${role} based in ${location}. Experience, education, and the tools I build with.`}
     >

--- a/pages/books.tsx
+++ b/pages/books.tsx
@@ -12,7 +12,7 @@ interface BooksPageProps {
 const Book = ({ books }: BooksPageProps) => {
   return (
     <Layout
-      pathname={'/books'}
+      canonicalPath="/books"
       pageTitle="Books"
       pageDescription="Books covering a variety of topics"
     >

--- a/pages/books/[id].tsx
+++ b/pages/books/[id].tsx
@@ -1,5 +1,4 @@
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 import React from 'react';
 import { GetStaticPropsContext } from 'next';
 import { Container, Layout } from '../../components';
@@ -12,11 +11,15 @@ import { getAllContentIds, getContentData } from '../../lib/content';
  */
 
 const Book = ({ bookData }: { bookData: IContentData }) => {
-  const { pathname } = useRouter();
   const { title, contentHtml, description } = bookData;
 
   return (
-    <Layout pathname={pathname} pageTitle={title} pageDescription={description}>
+    <Layout
+      canonicalPath={`/books/${encodeURIComponent(bookData.id)}`}
+      pageTitle={title}
+      pageDescription={description}
+      ogType="article"
+    >
       <Container width="narrow">
         <StyledContent>
           <time>
@@ -63,7 +66,10 @@ export interface IContentData {
 }
 
 export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
-  const bookData: IContentData = await getContentData(params?.id as string, 'book');
+  const bookData: IContentData = await getContentData(
+    params?.id as string,
+    'book'
+  );
 
   return {
     props: {

--- a/pages/books/categories/[category].tsx
+++ b/pages/books/categories/[category].tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import React from 'react';
 import { GetStaticPropsContext } from 'next';
 import { Container, Layout } from '../../../components';
@@ -10,12 +9,21 @@ interface CategoryPageProps {
   content: ContentListItem[];
   title: string;
   description: string;
+  category: string;
 }
 
-const Category = ({ content, title, description }: CategoryPageProps) => {
-  const { pathname } = useRouter();
+const Category = ({
+  content,
+  title,
+  description,
+  category,
+}: CategoryPageProps) => {
   return (
-    <Layout pageTitle={title} pathname={pathname} pageDescription={description}>
+    <Layout
+      canonicalPath={`/books/categories/${encodeURIComponent(category)}`}
+      pageTitle={title}
+      pageDescription={description}
+    >
       <Container width="narrow">
         <p className="page-intro">{description}</p>
         <NotesComponent notes={content} basePath="book" />
@@ -41,9 +49,10 @@ export const getStaticPaths = async () => {
 };
 
 export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
-  const content = getContentInCategory(params?.category as string, 'book');
+  const category = params?.category as string;
+  const content = getContentInCategory(category, 'book');
   const categoryObject = categoryJSON.filter(
-    (category) => category.category === params?.category
+    (entry) => entry.category === category
   )[0];
 
   return {
@@ -51,6 +60,7 @@ export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
       content,
       title: categoryObject.title,
       description: categoryObject.description,
+      category,
     },
   };
 };

--- a/pages/books/tags/[tag].tsx
+++ b/pages/books/tags/[tag].tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import React from 'react';
 import { GetStaticPropsContext } from 'next';
 import { Cards, Container, Layout } from '../../../components';
@@ -9,12 +8,16 @@ interface TagPageProps {
   content: ContentListItem[];
   title: string;
   description: string;
+  tag: string;
 }
 
-const Tag = ({ content, title, description }: TagPageProps) => {
-  const { pathname } = useRouter();
+const Tag = ({ content, title, description, tag }: TagPageProps) => {
   return (
-    <Layout pathname={pathname} pageTitle={title} pageDescription={description}>
+    <Layout
+      canonicalPath={`/books/tags/${encodeURIComponent(tag)}`}
+      pageTitle={title}
+      pageDescription={description}
+    >
       <Container>
         <p className="page-intro">{description}</p>
 
@@ -42,14 +45,16 @@ export const getStaticPaths = async () => {
 };
 
 export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
-  const content = getContentWithTag(params?.tag as string, 'book');
-  const tagObject = tagsJSON.filter((json) => json.tag === params?.tag)[0];
+  const tag = params?.tag as string;
+  const content = getContentWithTag(tag, 'book');
+  const tagObject = tagsJSON.filter((json) => json.tag === tag)[0];
 
   return {
     props: {
       content,
       title: tagObject.title,
       description: tagObject.description,
+      tag,
     },
   };
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ interface IndexPageProps {
  */
 const Index = ({ selectedWorks }: IndexPageProps) => {
   return (
-    <Layout pathname={'/'} pageTitle="Ryan Lewis Portfolio">
+    <Layout canonicalPath="/" pageTitle="Ryan Lewis Portfolio">
       <StyledIndexPage>
         <Container>
           <Cards data={selectedWorks} />

--- a/pages/projects.tsx
+++ b/pages/projects.tsx
@@ -12,7 +12,7 @@ interface ProjectsPageProps {
 const Project = ({ projects }: ProjectsPageProps) => {
   return (
     <Layout
-      pathname={'/projects'}
+      canonicalPath="/projects"
       pageTitle="Projects"
       pageDescription="Projects covering front end, machine learning, school associated courses, and research topics"
     >

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -2,7 +2,6 @@ import { faChrome, faYoutube } from '@fortawesome/free-brands-svg-icons';
 import { faCode } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Image from 'next/image';
-import { useRouter } from 'next/router';
 import React from 'react';
 import { GetStaticPropsContext } from 'next';
 import { Container, Layout } from '../../components';
@@ -21,10 +20,14 @@ interface ProjectPageProps {
  */
 
 const Project = ({ projectData }: ProjectPageProps) => {
-  const { pathname } = useRouter();
   const { title, contentHtml, description } = projectData;
   return (
-    <Layout pageTitle={title} pathname={pathname} pageDescription={description}>
+    <Layout
+      canonicalPath={`/projects/${encodeURIComponent(projectData.id)}`}
+      pageTitle={title}
+      pageDescription={description}
+      ogType="article"
+    >
       <Container width="narrow">
         <StyledContent>
           <time>
@@ -106,7 +109,10 @@ export const getStaticPaths = async () => {
 };
 
 export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
-  const projectData: IContentData = await getContentData(params?.id as string, 'project');
+  const projectData: IContentData = await getContentData(
+    params?.id as string,
+    'project'
+  );
 
   return {
     props: {

--- a/pages/projects/tags/[tag].tsx
+++ b/pages/projects/tags/[tag].tsx
@@ -1,4 +1,3 @@
-import { useRouter } from 'next/router';
 import React from 'react';
 import { GetStaticPropsContext } from 'next';
 import { Cards, Container, Layout } from '../../../components';
@@ -9,12 +8,16 @@ interface TagPageProps {
   content: ContentListItem[];
   title: string;
   description: string;
+  tag: string;
 }
 
-const Tag = ({ content, title, description }: TagPageProps) => {
-  const { pathname } = useRouter();
+const Tag = ({ content, title, description, tag }: TagPageProps) => {
   return (
-    <Layout pathname={pathname} pageTitle={title} pageDescription={description}>
+    <Layout
+      canonicalPath={`/projects/tags/${encodeURIComponent(tag)}`}
+      pageTitle={title}
+      pageDescription={description}
+    >
       <Container>
         <p className="page-intro">{description}</p>
 
@@ -42,14 +45,16 @@ export const getStaticPaths = async () => {
 };
 
 export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
-  const content = getContentWithTag(params?.tag as string, 'project');
-  const tagObject = tagsJSON.filter((json) => json.tag === params?.tag)[0];
+  const tag = params?.tag as string;
+  const content = getContentWithTag(tag, 'project');
+  const tagObject = tagsJSON.filter((json) => json.tag === tag)[0];
 
   return {
     props: {
       content,
       title: tagObject.title,
       description: tagObject.description,
+      tag,
     },
   };
 };

--- a/tests/page-metadata.spec.ts
+++ b/tests/page-metadata.spec.ts
@@ -77,6 +77,14 @@ const dynamicPages: MetadataExpectation[] = [
     type: 'website',
   },
   {
+    name: 'project tag page with spaced taxonomy slug',
+    route: '/projects/tags/machine%20learning',
+    canonicalPath: '/projects/tags/machine%20learning',
+    title: 'Machine Learning',
+    description: 'Machine Learning and Data Science topics',
+    type: 'website',
+  },
+  {
     name: 'book tag page',
     route: '/books/tags/management',
     canonicalPath: '/books/tags/management',

--- a/tests/page-metadata.spec.ts
+++ b/tests/page-metadata.spec.ts
@@ -1,0 +1,162 @@
+import { expect, test, type Page } from '@playwright/test';
+
+const SITE_ORIGIN = 'https://www.rylew.dev';
+const SOCIAL_IMAGE = `${SITE_ORIGIN}/Logo.png`;
+const SITE_DESCRIPTION = 'Ryan Lewis Portfolio';
+
+interface MetadataExpectation {
+  name: string;
+  route: string;
+  canonicalPath: string;
+  title: string;
+  description: string;
+  type: 'website' | 'article';
+}
+
+const staticPages: MetadataExpectation[] = [
+  {
+    name: 'homepage',
+    route: '/',
+    canonicalPath: '/',
+    title: 'Ryan Lewis Portfolio',
+    description: SITE_DESCRIPTION,
+    type: 'website',
+  },
+  {
+    name: 'static about page',
+    route: '/about',
+    canonicalPath: '/about',
+    title: 'About',
+    description:
+      'Senior Software Engineer based in Brooklyn, New York. Experience, education, and the tools I build with.',
+    type: 'website',
+  },
+  {
+    name: 'static projects page',
+    route: '/projects',
+    canonicalPath: '/projects',
+    title: 'Projects',
+    description:
+      'Projects covering front end, machine learning, school associated courses, and research topics',
+    type: 'website',
+  },
+  {
+    name: 'static books page',
+    route: '/books',
+    canonicalPath: '/books',
+    title: 'Books',
+    description: 'Books covering a variety of topics',
+    type: 'website',
+  },
+];
+
+const dynamicPages: MetadataExpectation[] = [
+  {
+    name: 'project detail page',
+    route: '/projects/cardgame',
+    canonicalPath: '/projects/cardgame',
+    title: 'Card Game',
+    description: 'Building a fullstack React/GraphQL/Django card game',
+    type: 'article',
+  },
+  {
+    name: 'book detail page',
+    route: '/books/accelerate',
+    canonicalPath: '/books/accelerate',
+    title: 'Accelerate: The Science of Lean Software and DevOps Review',
+    description:
+      'A practical, evidence-backed review of the definitive DevOps and software delivery performance book.',
+    type: 'article',
+  },
+  {
+    name: 'project tag page',
+    route: '/projects/tags/javascript',
+    canonicalPath: '/projects/tags/javascript',
+    title: 'JavaScript',
+    description: 'All things javascript',
+    type: 'website',
+  },
+  {
+    name: 'book tag page',
+    route: '/books/tags/management',
+    canonicalPath: '/books/tags/management',
+    title: 'Management',
+    description: 'Everything management related',
+    type: 'website',
+  },
+  {
+    name: 'book category page',
+    route: '/books/categories/weekly-notes',
+    canonicalPath: '/books/categories/weekly-notes',
+    title: 'Weekly Notes',
+    description:
+      "Weekly Notes are randomly curated links and resources of things I've learned in the past week. They include jams, podcasts and things I'm learning",
+    type: 'website',
+  },
+];
+
+const expectUniqueMeta = async (
+  page: Page,
+  selector: string,
+  expectedContent: string
+) => {
+  const metadata = page.locator(selector);
+  await expect(metadata).toHaveCount(1);
+  await expect(metadata).toHaveAttribute('content', expectedContent);
+};
+
+const expectPageMetadata = async (
+  page: Page,
+  metadata: MetadataExpectation
+) => {
+  const response = await page.goto(metadata.route);
+  expect(response?.ok()).toBeTruthy();
+
+  const expectedUrl = `${SITE_ORIGIN}${metadata.canonicalPath}`;
+  const canonical = page.locator('link[rel="canonical"]');
+
+  await expect(canonical).toHaveCount(1);
+  await expect(canonical).toHaveAttribute('href', expectedUrl);
+  await expectUniqueMeta(page, 'meta[property="og:url"]', expectedUrl);
+  await expectUniqueMeta(page, 'meta[property="og:type"]', metadata.type);
+  await expectUniqueMeta(page, 'meta[name="twitter:card"]', 'summary');
+  await expectUniqueMeta(page, 'meta[name="twitter:title"]', metadata.title);
+  await expectUniqueMeta(
+    page,
+    'meta[name="twitter:description"]',
+    metadata.description
+  );
+  await expectUniqueMeta(page, 'meta[name="twitter:image"]', SOCIAL_IMAGE);
+};
+
+for (const metadata of staticPages) {
+  test(`${metadata.name} emits unique page-specific metadata`, async ({
+    page,
+  }) => {
+    await expectPageMetadata(page, metadata);
+  });
+}
+
+for (const metadata of dynamicPages) {
+  test(`${metadata.name} emits unique page-specific metadata`, async ({
+    page,
+  }) => {
+    await expectPageMetadata(page, metadata);
+  });
+}
+
+test('query strings and hashes are excluded from canonical metadata', async ({
+  page,
+}) => {
+  const metadata: MetadataExpectation = {
+    name: 'projects query URL',
+    route: '/projects?utm_source=metadata#selected-work',
+    canonicalPath: '/projects',
+    title: 'Projects',
+    description:
+      'Projects covering front end, machine learning, school associated courses, and research topics',
+    type: 'website',
+  };
+
+  await expectPageMetadata(page, metadata);
+});


### PR DESCRIPTION
## Summary
- emit one absolute canonical URL and matching `og:url` for every site route
- derive dynamic project, book, tag, and category paths from build-time data instead of router placeholders
- mark project/book details as articles and complete Twitter title, description, and image metadata
- add focused production-server coverage for static and dynamic routes, uniqueness, and query/hash exclusion

## Test evidence
- `npx prettier --check <changed files>` — passed
- `npm run test:unit` — 33 passed
- `npm run build` — passed; 75 static pages generated
- focused Playwright metadata suite on production server, port 3106 — 10 passed
- full Playwright suite on production server, port 3106 — 34 passed