### PR TITLE
Clarify homepage hero and calls to action

### DIFF
--- a/components/header/home-header.tsx
+++ b/components/header/home-header.tsx
@@ -1,20 +1,30 @@
 import React from 'react';
 
+import { profile } from '../../lib/profile';
 import { Container } from '../container';
-import siteConfig from '../../config/index.json';
 import { StyledHomeHeading } from '../styles/header.styles';
 
 const HomeHeader = () => (
   <StyledHomeHeading aria-label="Page introduction">
     <Container>
       <div className="header-container">
-        <h1>{siteConfig.author.title}</h1>
-        <p
-          className="description"
-          dangerouslySetInnerHTML={{
-            __html: siteConfig.author.description,
-          }}
-        />
+        <h1>{profile.name}</h1>
+        <p className="identity">
+          {profile.role} · {profile.location}
+        </p>
+        <p className="description">
+          I build accessible, maintainable digital services with React,
+          TypeScript, Python, and Node.js.
+        </p>
+        <nav className="hero-actions" aria-label="Homepage actions">
+          <a className="primary" href="/projects">
+            View projects
+          </a>
+          {profile.links.resume && (
+            <a href={profile.links.resume}>Resume</a>
+          )}
+          <a href={`mailto:${profile.links.email}`}>Contact</a>
+        </nav>
       </div>
     </Container>
   </StyledHomeHeading>

--- a/components/header/home-header.tsx
+++ b/components/header/home-header.tsx
@@ -20,9 +20,7 @@ const HomeHeader = () => (
           <a className="primary" href="/projects">
             View projects
           </a>
-          {profile.links.resume && (
-            <a href={profile.links.resume}>Resume</a>
-          )}
+          {profile.links.resume && <a href={profile.links.resume}>Resume</a>}
           <a href={`mailto:${profile.links.email}`}>Contact</a>
         </nav>
       </div>

--- a/components/styles/header.styles.ts
+++ b/components/styles/header.styles.ts
@@ -4,6 +4,58 @@ export const StyledHomeHeading = styled.section`
   h1 {
     color: var(--header-title);
   }
+
+  .identity {
+    margin-bottom: 0.75rem;
+    color: var(--text-color);
+    font-weight: 600;
+  }
+
+  .description {
+    max-width: 42rem;
+  }
+
+  .hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 2rem;
+  }
+
+  .hero-actions a {
+    display: inline-flex;
+    min-height: 44px;
+    align-items: center;
+    justify-content: center;
+    padding: 0.65rem 1rem;
+    border: 1px solid var(--prim-color);
+    border-radius: 5px;
+    color: var(--prim-color);
+    font-weight: bold;
+    line-height: 1.2;
+    text-decoration: none;
+
+    &:hover {
+      background: var(--surface-muted);
+      color: var(--link-hover);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--prim-color);
+      outline-offset: 2px;
+    }
+  }
+
+  .hero-actions .primary {
+    background: var(--prim-color);
+    color: var(--surface);
+
+    &:hover {
+      background: var(--link-hover);
+      color: var(--surface);
+    }
+  }
+
   @media (min-width: 1024px) {
     .header-container {
       max-width: 70%;

--- a/docs/superpowers/plans/2026-07-28-homepage-hero-cta.md
+++ b/docs/superpowers/plans/2026-07-28-homepage-hero-cta.md
@@ -1,0 +1,103 @@
+# Homepage Hero and Calls to Action Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the homepage immediately identify Ryan, communicate his engineering focus, and provide clear routes to projects, résumé, and contact.
+
+**Architecture:** Keep the existing homepage structure and restrained visual language. Render the approved identity, positioning, and CTA content in `HomeHeader`, sourcing stable profile fields and links from `me/profile.json`, and extend the existing header styles without changing project cards or global metadata.
+
+**Tech Stack:** Next.js Pages Router, React, TypeScript, styled-components, Playwright
+
+## Global Constraints
+
+- Base all work on commit `4cdf4d9233b8e1ac316f735fa53bc26e7a6aa43d`.
+- Preserve the current homepage project list, navigation, themes, and mobile layout.
+- Use the exact identity line `Senior Software Engineer · Brooklyn, New York`.
+- Use the exact positioning sentence `I build accessible, maintainable digital services with React, TypeScript, Python, and Node.js.`
+- Provide three CTAs: `View projects` to `/projects`, `Resume` to `/Ryan-Lewis-Resume.pdf`, and `Contact` to `mailto:ryanlewis312@gmail.com`.
+- Do not modify global SEO/social metadata; that belongs to the separate positioning PR.
+- Add no dependencies.
+
+---
+
+### Task 1: Lock the hero contract with a failing browser test
+
+**Files:**
+- Create: `tests/homepage-hero.spec.ts`
+
+**Interfaces:**
+- Consumes: the production homepage at `/`
+- Produces: a regression contract for the H1, supporting copy, and CTA destinations
+
+- [ ] **Step 1: Write the failing test**
+
+Create a Playwright test that opens `/`, asserts the single level-one heading is `Ryan Lewis`, checks the exact identity and positioning lines, and checks the three named links have the exact `href` values from Global Constraints.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run the test against a production build on an isolated non-3000 port with `reuseExistingServer: false`.
+
+Expected: FAIL because the current heading is `Ryan Lewis Portfolio` and the CTAs do not exist.
+
+- [ ] **Step 3: Commit the test**
+
+Commit only the focused failing test with a message describing the homepage hero contract.
+
+### Task 2: Implement the approved hero and CTA treatment
+
+**Files:**
+- Modify: `components/header/home-header.tsx`
+- Modify: `components/styles/header.styles.ts`
+- Test: `tests/homepage-hero.spec.ts`
+
+**Interfaces:**
+- Consumes: `role`, `location`, `bio`, and `links` from `me/profile.json`
+- Produces: the visible homepage identity, positioning line, and three keyboard-accessible links
+
+- [ ] **Step 1: Replace the generic hero content**
+
+Render an H1 of `Ryan Lewis`, the exact identity line, and the exact positioning sentence. Use profile data for the role, location, résumé URL, and email destination where it produces the approved text and URLs without duplicating mutable values.
+
+- [ ] **Step 2: Add the CTA group**
+
+Render `View projects` as the primary CTA and `Resume` and `Contact` as secondary links. Preserve native anchor behavior, visible focus indicators, sufficient contrast in both themes, and comfortable touch targets.
+
+- [ ] **Step 3: Extend the existing styles**
+
+Keep the current typography and spacing character. Add only the layout, responsive wrapping, hover, and focus styling required for the new content and CTA group.
+
+- [ ] **Step 4: Run the focused test to verify it passes**
+
+Run the same isolated production Playwright command.
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit the implementation**
+
+Commit the component, style, and focused test changes.
+
+### Task 3: Verify and open an unmerged PR
+
+**Files:**
+- Modify only if verification exposes a defect in this PR's scope
+
+**Interfaces:**
+- Consumes: the completed hero branch
+- Produces: a pushed branch and open PR targeting `master`
+
+- [ ] **Step 1: Format and inspect**
+
+Run Prettier on changed source and test files, `git diff --check`, and inspect the final diff for unrelated changes.
+
+- [ ] **Step 2: Run verification**
+
+Run `npm run test:unit`, `npm run build`, the focused test, and the full production Playwright suite on an isolated port. Restore generated drift in `me/chat-context.json`, `me/summary.txt`, `next-env.d.ts`, and `tsconfig.json` if the commands modify files.
+
+- [ ] **Step 3: Commit any scoped verification fixes**
+
+Use TDD for any behavior fix, then repeat the affected checks.
+
+- [ ] **Step 4: Push and open the PR**
+
+Push `tier1/homepage-hero-cta` and open an unmerged PR against `master`. The PR body must state the exact hero copy, CTA destinations, and verification evidence.
+

--- a/docs/superpowers/plans/2026-07-28-homepage-hero-cta.md
+++ b/docs/superpowers/plans/2026-07-28-homepage-hero-cta.md
@@ -100,4 +100,3 @@ Use TDD for any behavior fix, then repeat the affected checks.
 - [ ] **Step 4: Push and open the PR**
 
 Push `tier1/homepage-hero-cta` and open an unmerged PR against `master`. The PR body must state the exact hero copy, CTA destinations, and verification evidence.
-

--- a/tests/homepage-hero.spec.ts
+++ b/tests/homepage-hero.spec.ts
@@ -1,34 +1,34 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from '@playwright/test';
 
 test("homepage hero presents Ryan's identity and primary routes", async ({
   page,
 }) => {
-  await page.goto("/");
+  await page.goto('/');
 
-  const hero = page.getByLabel("Page introduction");
+  const hero = page.getByLabel('Page introduction');
+  const heading = page.getByRole('heading', { level: 1 });
 
+  await expect(heading).toHaveCount(1);
+  await expect(heading).toHaveText('Ryan Lewis');
   await expect(
-    page.getByRole("heading", { level: 1, name: "Ryan Lewis", exact: true })
-  ).toHaveCount(1);
-  await expect(
-    hero.getByText("Senior Software Engineer · Brooklyn, New York", {
+    hero.getByText('Senior Software Engineer · Brooklyn, New York', {
       exact: true,
     })
   ).toBeVisible();
   await expect(
     hero.getByText(
-      "I build accessible, maintainable digital services with React, TypeScript, Python, and Node.js.",
+      'I build accessible, maintainable digital services with React, TypeScript, Python, and Node.js.',
       { exact: true }
     )
   ).toBeVisible();
 
   await expect(
-    hero.getByRole("link", { name: "View projects", exact: true })
-  ).toHaveAttribute("href", "/projects");
+    hero.getByRole('link', { name: 'View projects', exact: true })
+  ).toHaveAttribute('href', '/projects');
   await expect(
-    hero.getByRole("link", { name: "Resume", exact: true })
-  ).toHaveAttribute("href", "/Ryan-Lewis-Resume.pdf");
+    hero.getByRole('link', { name: 'Resume', exact: true })
+  ).toHaveAttribute('href', '/Ryan-Lewis-Resume.pdf');
   await expect(
-    hero.getByRole("link", { name: "Contact", exact: true })
-  ).toHaveAttribute("href", "mailto:ryanlewis312@gmail.com");
+    hero.getByRole('link', { name: 'Contact', exact: true })
+  ).toHaveAttribute('href', 'mailto:ryanlewis312@gmail.com');
 });

--- a/tests/homepage-hero.spec.ts
+++ b/tests/homepage-hero.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+test("homepage hero presents Ryan's identity and primary routes", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const hero = page.getByLabel("Page introduction");
+
+  await expect(
+    page.getByRole("heading", { level: 1, name: "Ryan Lewis", exact: true })
+  ).toHaveCount(1);
+  await expect(
+    hero.getByText("Senior Software Engineer · Brooklyn, New York", {
+      exact: true,
+    })
+  ).toBeVisible();
+  await expect(
+    hero.getByText(
+      "I build accessible, maintainable digital services with React, TypeScript, Python, and Node.js.",
+      { exact: true }
+    )
+  ).toBeVisible();
+
+  await expect(
+    hero.getByRole("link", { name: "View projects", exact: true })
+  ).toHaveAttribute("href", "/projects");
+  await expect(
+    hero.getByRole("link", { name: "Resume", exact: true })
+  ).toHaveAttribute("href", "/Ryan-Lewis-Resume.pdf");
+  await expect(
+    hero.getByRole("link", { name: "Contact", exact: true })
+  ).toHaveAttribute("href", "mailto:ryanlewis312@gmail.com");
+});


### PR DESCRIPTION
## Summary

- Change the homepage H1 to `Ryan Lewis` and add the exact identity line `Senior Software Engineer · Brooklyn, New York`.
- Add the exact positioning sentence `I build accessible, maintainable digital services with React, TypeScript, Python, and Node.js.`
- Add native, keyboard-accessible hero CTAs:
  - `View projects` → `/projects`
  - `Resume` → `/Ryan-Lewis-Resume.pdf`
  - `Contact` → `mailto:ryanlewis312@gmail.com`
- Source mutable identity and link values from `me/profile.json` and add focused responsive, hover, and focus styles.
- Preserve global metadata, chat behavior, selected projects, navigation, themes, and mobile layout.

## Verification

- TDD RED: focused production Playwright failed before implementation because the exact `Ryan Lewis` H1 was absent (isolated port 4187, `reuseExistingServer: false`).
- Mutation RED: the strengthened single-H1 assertion failed against `Ryan Lewis Portfolio` as expected (isolated port 4193).
- `npm run test:unit` — 42 passed, 0 failed.
- `npm run build` — exit 0, 45 static pages generated; only the existing worktree-root/file-tracing warnings were emitted.
- Focused production Playwright — 1 passed on isolated port 4195 with `reuseExistingServer: false`.
- Full production Playwright — 31 passed on isolated port 4197 with `reuseExistingServer: false`.
- Prettier check and `git diff --check` — clean.