### PR TITLE
Improve project and book detail image alt text

### DIFF
--- a/pages/books/[id].tsx
+++ b/pages/books/[id].tsx
@@ -27,7 +27,7 @@ const Book = ({ bookData }: { bookData: IContentData }) => {
           {bookData.tags && <Chips items={bookData.tags} />}
           {bookData.previewImage && (
             <Image
-              alt="bookimage"
+              alt={`${title} book cover`}
               src={bookData.previewImage}
               height={550}
               width={1200}

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -35,7 +35,7 @@ const Project = ({ projectData }: ProjectPageProps) => {
           {projectData.tags && <Chips items={projectData.tags} />}
           {projectData.previewImage && (
             <Image
-              alt="projectimage"
+              alt={`${title} project preview`}
               src={projectData.previewImage}
               height={550}
               width={1200}

--- a/tests/detail-image-alt.spec.ts
+++ b/tests/detail-image-alt.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from '@playwright/test';
+import { getContentList } from '../lib/content';
+
+const detailImageCases = [
+  {
+    contentType: 'project',
+    route: 'projects',
+    imageDescription: 'project preview',
+  },
+  {
+    contentType: 'book',
+    route: 'books',
+    imageDescription: 'book cover',
+  },
+] as const;
+
+for (const { contentType, route, imageDescription } of detailImageCases) {
+  test(`${contentType} detail image uses content-derived alt text`, async ({
+    page,
+  }) => {
+    const item = getContentList(contentType).find(
+      ({ previewImage, slug, title }) => previewImage && slug && title
+    );
+
+    expect(item).toBeDefined();
+    await page.goto(`/${route}/${item!.slug}`);
+
+    await expect(
+      page.getByRole('img', {
+        name: `${item!.title} ${imageDescription}`,
+      })
+    ).toBeVisible();
+    await expect(
+      page.getByRole('img', { name: /^(projectimage|bookimage)$/i })
+    ).toHaveCount(0);
+  });
+}


### PR DESCRIPTION
## Summary
- replace generic project detail image alt text with the project title plus `project preview`
- replace generic book detail image alt text with the book title plus `book cover`
- add focused Playwright coverage that renders both detail page types and rejects the old generic values

## Scope
- content/accessibility only
- no layout, styling, dependency, or behavior changes

## TDD evidence
- RED: `npx playwright test tests/content-pages.spec.ts -g "detail image"` failed 2/2 because the content-derived accessible names did not exist
- GREEN: the equivalent focused regression file passed 2/2 after the two minimal alt changes

## Verification
- `npm run test:unit` ? 42 passed
- `npm run build` ? passed; 45 routes generated
- `npx playwright test tests/detail-image-alt.spec.ts` ? 2 passed
- `npm run test:e2e` ? 46 passed against the verified production build
- `npx prettier --check tests/detail-image-alt.spec.ts` ? passed
- `git diff --check` ? passed

## Notes
- Repository-wide `npm run format:check` currently reports pre-existing style issues across 115 files, so formatting verification was scoped to the new regression file.
- Local verification ran on Node 24 while CI and the project engine use Node 22; GitHub/Vercel checks provide the declared-runtime result.
