### PR TITLE
Add portfolio conversion analytics

### DIFF
--- a/components/cards/cards.tsx
+++ b/components/cards/cards.tsx
@@ -4,6 +4,10 @@ import React from 'react';
 import { StyledCards } from '../styles/cards.styles';
 import { useRouter } from 'next/router';
 import { ContentListItem } from '../../lib/content';
+import {
+  CONVERSION_EVENTS,
+  trackConversion,
+} from '../../lib/conversion-analytics';
 
 interface CardsProps {
   data: ContentListItem[];
@@ -42,6 +46,16 @@ const Cards = ({ data }: CardsProps) => {
               href={`/${singleCard.path}/[id]`}
               as={`/${singleCard.path}/${singleCard.slug}`}
               className="card-link"
+              onClick={
+                singleCard.path === 'projects' && singleCard.slug
+                  ? () =>
+                      trackConversion(CONVERSION_EVENTS.projectVisit, {
+                        destination: 'detail',
+                        location: 'card',
+                        project_slug: singleCard.slug!,
+                      })
+                  : undefined
+              }
             >
               <h2>{singleCard.title}</h2>
             </Link>
@@ -103,6 +117,16 @@ function getDemoButtons(singleCard: ContentListItem) {
           rel="noreferrer noopener"
           aria-label={`${singleCard.title} demo`}
           className="card-action a-demo demo"
+          onClick={
+            singleCard.path === 'projects' && singleCard.slug
+              ? () =>
+                  trackConversion(CONVERSION_EVENTS.projectVisit, {
+                    destination: 'demo',
+                    location: 'card',
+                    project_slug: singleCard.slug!,
+                  })
+              : undefined
+          }
         >
           Demo
         </a>
@@ -114,6 +138,16 @@ function getDemoButtons(singleCard: ContentListItem) {
           rel="noreferrer noopener"
           aria-label={`${singleCard.title} source code`}
           className="card-action a-source source"
+          onClick={
+            singleCard.path === 'projects' && singleCard.slug
+              ? () =>
+                  trackConversion(CONVERSION_EVENTS.projectVisit, {
+                    destination: 'source',
+                    location: 'card',
+                    project_slug: singleCard.slug!,
+                  })
+              : undefined
+          }
         >
           Source
         </a>

--- a/components/chat/chat-widget.tsx
+++ b/components/chat/chat-widget.tsx
@@ -16,6 +16,10 @@ import {
   LoadingDots,
   LoadingStatusText,
 } from './chat-widget.styles';
+import {
+  CONVERSION_EVENTS,
+  trackConversion,
+} from '../../lib/conversion-analytics';
 
 interface ChatMessage {
   role: 'user' | 'assistant';
@@ -155,6 +159,9 @@ const ChatWidget: React.FC = () => {
           ...prev,
           { role: 'assistant', content: data.response },
         ]);
+        if (response.ok) {
+          trackConversion(CONVERSION_EVENTS.chatSubmitSuccess);
+        }
       }
     } catch {
       setMessages((prev) => [
@@ -258,7 +265,10 @@ const ChatWidget: React.FC = () => {
       {!isOpen && (
         <ChatButton
           ref={launcherRef}
-          onClick={() => setIsOpen(true)}
+          onClick={() => {
+            trackConversion(CONVERSION_EVENTS.chatOpen);
+            setIsOpen(true);
+          }}
           aria-label="Open chat"
         >
           <ChatIcon />

--- a/components/footer/footer.tsx
+++ b/components/footer/footer.tsx
@@ -6,6 +6,10 @@ import React from 'react';
 import { Container } from '../container';
 import { StyledFooterSection } from '../styles/footer.styles';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
+import {
+  CONVERSION_EVENTS,
+  trackConversion,
+} from '../../lib/conversion-analytics';
 
 const Footer = () => (
   <>
@@ -22,6 +26,12 @@ const Footer = () => (
               target="_blank"
               rel="noreferrer noopener"
               aria-label="linkedin"
+              onClick={() =>
+                trackConversion(CONVERSION_EVENTS.contactClick, {
+                  channel: 'linkedin',
+                  location: 'footer',
+                })
+              }
             >
               <div className="footerIcon linkedin">
                 <FontAwesomeIcon icon={faLinkedin as IconProp} size="lg" />
@@ -49,6 +59,12 @@ const Footer = () => (
               target="_blank"
               rel="noreferrer noopener"
               aria-label="email"
+              onClick={() =>
+                trackConversion(CONVERSION_EVENTS.contactClick, {
+                  channel: 'email',
+                  location: 'footer',
+                })
+              }
             >
               <div className="footerIcon email envelope">
                 <FontAwesomeIcon icon={faEnvelope as IconProp} size="lg" />

--- a/components/nav/nav.tsx
+++ b/components/nav/nav.tsx
@@ -3,6 +3,10 @@ import { useRouter } from 'next/router';
 import React, { useContext } from 'react';
 import { MenuContext, ThemeContext } from '..';
 import SiteConfig from '../../config/index.json';
+import {
+  CONVERSION_EVENTS,
+  trackConversion,
+} from '../../lib/conversion-analytics';
 import { profile } from '../../lib/profile';
 import { Container } from '../container';
 import Logo from '../logo';
@@ -75,6 +79,15 @@ const Nav = () => {
                         target="_blank"
                         rel="noopener noreferrer"
                         className="navLinkAnchor"
+                        onClick={
+                          item.title === 'Resume'
+                            ? () =>
+                                trackConversion(
+                                  CONVERSION_EVENTS.resumeDownload,
+                                  { location: 'navigation' }
+                                )
+                            : undefined
+                        }
                       >
                         {item.title}
                       </a>

--- a/lib/conversion-analytics.ts
+++ b/lib/conversion-analytics.ts
@@ -1,0 +1,52 @@
+import { track } from '@vercel/analytics';
+
+export const CONVERSION_EVENTS = {
+  resumeDownload: 'resume_download',
+  contactClick: 'contact_click',
+  projectVisit: 'project_visit',
+  chatOpen: 'chat_open',
+  chatSubmitSuccess: 'chat_submit_success',
+} as const;
+
+interface ConversionEventProperties {
+  resume_download: {
+    location: 'navigation' | 'about';
+  };
+  contact_click: {
+    channel: 'email' | 'linkedin';
+    location: 'footer';
+  };
+  project_visit: {
+    destination: 'detail' | 'demo' | 'source';
+    location: 'card' | 'project_detail';
+    project_slug: string;
+  };
+  chat_open: undefined;
+  chat_submit_success: undefined;
+}
+
+type ConversionEventName = keyof ConversionEventProperties;
+type ConversionEventArguments<EventName extends ConversionEventName> =
+  ConversionEventProperties[EventName] extends undefined
+    ? []
+    : [properties: ConversionEventProperties[EventName]];
+
+/**
+ * Sends a deliberately small, typed conversion event catalog to the site's
+ * existing Vercel Analytics integration. Analytics must never interrupt the
+ * visitor action it observes.
+ */
+export function trackConversion<EventName extends ConversionEventName>(
+  eventName: EventName,
+  ...args: ConversionEventArguments<EventName>
+): void {
+  if (typeof window === 'undefined') return;
+
+  try {
+    const properties = args[0] as
+      Record<string, string | number | boolean | null> | undefined;
+    track(eventName, properties);
+  } catch {
+    // Tracking is optional and can be unavailable or blocked by the visitor.
+  }
+}

--- a/pages/about.tsx
+++ b/pages/about.tsx
@@ -2,6 +2,10 @@ import Image from 'next/image';
 import React from 'react';
 import { Container, Layout } from '../components';
 import { StyledAbout } from '../components/styles/about.styles';
+import {
+  CONVERSION_EVENTS,
+  trackConversion,
+} from '../lib/conversion-analytics';
 import { profile } from '../lib/profile';
 
 /**
@@ -57,6 +61,11 @@ const About = () => {
                     href={links.resume}
                     target="_blank"
                     rel="noopener noreferrer"
+                    onClick={() =>
+                      trackConversion(CONVERSION_EVENTS.resumeDownload, {
+                        location: 'about',
+                      })
+                    }
                   >
                     Résumé (PDF)
                   </a>

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -9,6 +9,10 @@ import { Container, Layout } from '../../components';
 import { Chips } from '../../components/chips/chips';
 import { StyledContent } from '../../components/styles/content.styles';
 import { getAllContentIds, getContentData } from '../../lib/content';
+import {
+  CONVERSION_EVENTS,
+  trackConversion,
+} from '../../lib/conversion-analytics';
 import { IContentData } from '../books/[id]';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
 
@@ -48,6 +52,13 @@ const Project = ({ projectData }: ProjectPageProps) => {
                   href={projectData.liveSite}
                   target="_blank"
                   rel="noreferrer noopener"
+                  onClick={() =>
+                    trackConversion(CONVERSION_EVENTS.projectVisit, {
+                      destination: 'demo',
+                      location: 'project_detail',
+                      project_slug: projectData.id,
+                    })
+                  }
                 >
                   <FontAwesomeIcon
                     className="callout-icon demo"
@@ -65,6 +76,13 @@ const Project = ({ projectData }: ProjectPageProps) => {
                   target="_blank"
                   rel="noreferrer noopener"
                   style={{ display: 'inline-block' }}
+                  onClick={() =>
+                    trackConversion(CONVERSION_EVENTS.projectVisit, {
+                      destination: 'source',
+                      location: 'project_detail',
+                      project_slug: projectData.id,
+                    })
+                  }
                 >
                   <FontAwesomeIcon
                     className="callout-icon source"
@@ -106,7 +124,10 @@ export const getStaticPaths = async () => {
 };
 
 export const getStaticProps = async ({ params }: GetStaticPropsContext) => {
-  const projectData: IContentData = await getContentData(params?.id as string, 'project');
+  const projectData: IContentData = await getContentData(
+    params?.id as string,
+    'project'
+  );
 
   return {
     props: {

--- a/tests/conversion-analytics.spec.ts
+++ b/tests/conversion-analytics.spec.ts
@@ -1,0 +1,245 @@
+import { expect, test, type Locator, type Page } from '@playwright/test';
+import { getContentList } from '../lib/content';
+
+interface CapturedEvent {
+  name: string;
+  data?: Record<string, unknown>;
+}
+
+const installAnalyticsCapture = async (page: Page) => {
+  await page.route('https://va.vercel-scripts.com/**', (route) =>
+    route.abort()
+  );
+  await page.addInitScript(() => {
+    const events: CapturedEvent[] = [];
+    const testWindow = window as typeof window & {
+      __conversionEvents: CapturedEvent[];
+    };
+
+    testWindow.__conversionEvents = events;
+    testWindow.va = (command, payload) => {
+      if (
+        command === 'event' &&
+        payload &&
+        typeof payload === 'object' &&
+        'name' in payload
+      ) {
+        events.push(payload as CapturedEvent);
+      }
+    };
+  });
+};
+
+const getEvents = (page: Page) =>
+  page.evaluate(
+    () =>
+      (
+        window as typeof window & {
+          __conversionEvents?: CapturedEvent[];
+        }
+      ).__conversionEvents ?? []
+  );
+
+const clickWithoutNavigation = async (locator: Locator) => {
+  await locator.evaluate((element) => {
+    element.addEventListener('click', (event) => event.preventDefault(), {
+      capture: true,
+      once: true,
+    });
+  });
+  await locator.click();
+};
+
+test.beforeEach(async ({ page }) => {
+  await installAnalyticsCapture(page);
+});
+
+test('tracks resume and contact conversions at their interaction sources', async ({
+  page,
+}) => {
+  await page.goto('/about');
+
+  await clickWithoutNavigation(
+    page.locator('nav').getByRole('link', { name: 'Resume' })
+  );
+  await clickWithoutNavigation(
+    page.getByRole('main').getByRole('link', { name: 'Résumé (PDF)' })
+  );
+  await clickWithoutNavigation(
+    page.getByRole('contentinfo').getByRole('link', { name: 'linkedin' })
+  );
+  await clickWithoutNavigation(
+    page.getByRole('contentinfo').getByRole('link', { name: 'email' })
+  );
+
+  await expect
+    .poll(() => getEvents(page))
+    .toEqual([
+      {
+        name: 'resume_download',
+        data: { location: 'navigation' },
+      },
+      {
+        name: 'resume_download',
+        data: { location: 'about' },
+      },
+      {
+        name: 'contact_click',
+        data: { channel: 'linkedin', location: 'footer' },
+      },
+      {
+        name: 'contact_click',
+        data: { channel: 'email', location: 'footer' },
+      },
+    ]);
+});
+
+test('tracks project detail, demo, and source visits without changing links', async ({
+  page,
+}) => {
+  test.slow();
+  const project = getContentList('project').find(
+    (item) =>
+      item.slug &&
+      item.title &&
+      item.liveSite &&
+      item.sourceCode &&
+      item.path === 'projects'
+  );
+
+  if (!project) {
+    throw new Error('No project has detail, demo, and source destinations.');
+  }
+
+  await page.goto('/projects');
+  const card = page
+    .locator('main article')
+    .filter({ has: page.getByRole('heading', { name: project.title! }) })
+    .first();
+
+  const detail = card.getByRole('link', {
+    name: project.title!,
+    exact: true,
+  });
+  const demo = card.getByRole('link', { name: `${project.title} demo` });
+  const source = card.getByRole('link', {
+    name: `${project.title} source code`,
+  });
+
+  await expect(detail).toHaveAttribute('href', `/projects/${project.slug}`);
+  await expect(demo).toHaveAttribute('href', project.liveSite!);
+  await expect(source).toHaveAttribute('href', project.sourceCode!);
+
+  await clickWithoutNavigation(detail);
+  await clickWithoutNavigation(demo);
+  await clickWithoutNavigation(source);
+
+  await expect
+    .poll(() => getEvents(page))
+    .toEqual([
+      {
+        name: 'project_visit',
+        data: {
+          destination: 'detail',
+          location: 'card',
+          project_slug: project.slug,
+        },
+      },
+      {
+        name: 'project_visit',
+        data: {
+          destination: 'demo',
+          location: 'card',
+          project_slug: project.slug,
+        },
+      },
+      {
+        name: 'project_visit',
+        data: {
+          destination: 'source',
+          location: 'card',
+          project_slug: project.slug,
+        },
+      },
+    ]);
+
+  await page.goto(`/projects/${project.slug}`);
+  const projectCallouts = page.locator('main blockquote');
+  const detailDemo = projectCallouts.getByRole('link', {
+    name: /^Demo:/,
+  });
+  const detailSource = projectCallouts.getByRole('link', {
+    name: /^Source Code:/,
+  });
+
+  await expect(detailDemo).toHaveAttribute('href', project.liveSite!);
+  await expect(detailSource).toHaveAttribute('href', project.sourceCode!);
+
+  await clickWithoutNavigation(detailDemo);
+  await clickWithoutNavigation(detailSource);
+
+  await expect
+    .poll(() => getEvents(page))
+    .toEqual([
+      {
+        name: 'project_visit',
+        data: {
+          destination: 'demo',
+          location: 'project_detail',
+          project_slug: project.slug,
+        },
+      },
+      {
+        name: 'project_visit',
+        data: {
+          destination: 'source',
+          location: 'project_detail',
+          project_slug: project.slug,
+        },
+      },
+    ]);
+});
+
+test('tracks chat opens and only successful submissions without visitor text', async ({
+  page,
+}) => {
+  await page.route('**/api/chat', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ response: 'A safe response.' }),
+    })
+  );
+  await page.goto('/');
+
+  await page.getByRole('button', { name: 'Open chat' }).click();
+  const question = 'PRIVATE ANALYTICS TEST QUESTION';
+  await page.getByLabel('Your question').fill(question);
+  await page.getByLabel('Your question').press('Enter');
+  await expect(
+    page.getByText('A safe response.', { exact: true })
+  ).toBeVisible();
+
+  await page.unroute('**/api/chat');
+  await page.route('**/api/chat', (route) =>
+    route.fulfill({
+      status: 500,
+      contentType: 'application/json',
+      body: JSON.stringify({ error: 'Unavailable' }),
+    })
+  );
+  const failedQuestion = 'SECOND PRIVATE ANALYTICS TEST QUESTION';
+  await page.getByLabel('Your question').fill(failedQuestion);
+  await page.getByLabel('Your question').press('Enter');
+  await expect(
+    page.getByText(/assistant is having trouble connecting/i)
+  ).toBeVisible();
+
+  const events = await getEvents(page);
+  expect(events).toEqual([
+    { name: 'chat_open' },
+    { name: 'chat_submit_success' },
+  ]);
+  expect(JSON.stringify(events)).not.toContain(question);
+  expect(JSON.stringify(events)).not.toContain(failedQuestion);
+});

--- a/tests/conversion-analytics.test.ts
+++ b/tests/conversion-analytics.test.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  CONVERSION_EVENTS,
+  trackConversion,
+} from '../lib/conversion-analytics';
+
+const originalWindowDescriptor = Object.getOwnPropertyDescriptor(
+  globalThis,
+  'window'
+);
+
+test.afterEach(() => {
+  if (originalWindowDescriptor) {
+    Object.defineProperty(globalThis, 'window', originalWindowDescriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, 'window');
+  }
+});
+
+test('sends stable conversion names and low-cardinality metadata to Vercel Analytics', () => {
+  const calls: unknown[][] = [];
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      va: (...args: unknown[]) => calls.push(args),
+    },
+  });
+
+  trackConversion(CONVERSION_EVENTS.resumeDownload, {
+    location: 'navigation',
+  });
+  trackConversion(CONVERSION_EVENTS.contactClick, {
+    channel: 'linkedin',
+    location: 'footer',
+  });
+  trackConversion(CONVERSION_EVENTS.projectVisit, {
+    destination: 'source',
+    location: 'project_detail',
+    project_slug: 'cardgame',
+  });
+  trackConversion(CONVERSION_EVENTS.chatOpen);
+  trackConversion(CONVERSION_EVENTS.chatSubmitSuccess);
+
+  assert.deepEqual(calls, [
+    [
+      'event',
+      {
+        name: 'resume_download',
+        data: { location: 'navigation' },
+        options: undefined,
+      },
+    ],
+    [
+      'event',
+      {
+        name: 'contact_click',
+        data: { channel: 'linkedin', location: 'footer' },
+        options: undefined,
+      },
+    ],
+    [
+      'event',
+      {
+        name: 'project_visit',
+        data: {
+          destination: 'source',
+          location: 'project_detail',
+          project_slug: 'cardgame',
+        },
+        options: undefined,
+      },
+    ],
+    ['event', { name: 'chat_open', options: undefined }],
+    ['event', { name: 'chat_submit_success', options: undefined }],
+  ]);
+});
+
+test('does not throw when analytics is unavailable', () => {
+  assert.doesNotThrow(() =>
+    trackConversion(CONVERSION_EVENTS.chatSubmitSuccess)
+  );
+
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {},
+  });
+
+  assert.doesNotThrow(() => trackConversion(CONVERSION_EVENTS.chatOpen));
+});
+
+test('does not disrupt visitor actions when the analytics transport fails', () => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      va: () => {
+        throw new Error('analytics blocked');
+      },
+    },
+  });
+
+  assert.doesNotThrow(() =>
+    trackConversion(CONVERSION_EVENTS.resumeDownload, {
+      location: 'about',
+    })
+  );
+});


### PR DESCRIPTION
## Summary
- add one typed, failure-isolated helper around the existing Vercel Analytics integration
- instrument resume, contact, project, and chat conversion interactions without changing navigation or chat behavior
- add focused unit and Playwright coverage for the event contract, interaction wiring, Enter-to-submit, failure handling, and privacy boundary

## Event catalog
| Event | Metadata | Trigger |
| --- | --- | --- |
| `resume_download` | `location`: `navigation` or `about` | Resume PDF link click |
| `contact_click` | `channel`: `email` or `linkedin`; `location`: `footer` | Footer contact link click |
| `project_visit` | `destination`: `detail`, `demo`, or `source`; `location`: `card` or `project_detail`; bounded `project_slug` | Project detail/demo/source link click |
| `chat_open` | none | Chat launcher click |
| `chat_submit_success` | none | Successful chat API response |

## Privacy scope
- uses the site's existing Vercel Analytics provider; no new vendor, dependency, cookie, or consent behavior
- sends only fixed event names and bounded content/location metadata
- never sends chat text, email addresses, API responses, or other visitor-entered/PII content
- safely no-ops if analytics is unavailable or blocked

## TDD and verification
- confirmed focused tests RED before implementation, then GREEN
- focused analytics unit tests: 3 passed
- full unit suite: 45 passed
- focused analytics Playwright tests: 3 passed
- full Playwright suite against the production build on an isolated port: 47 passed
- production build: passed (45 routes)
- scoped Prettier check for all changed files: passed
- `git diff --check`: passed

Repository-wide `npm run format:check` and standalone `tsc --noEmit` still report pre-existing baseline issues outside this change; Next.js production TypeScript/build validation passes.

Closes #19