### PR TITLE
Add a lightweight mobile performance budget

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,9 +24,15 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run unit tests
+        run: npm run test:unit
+
       # Runs prebuild (generate:context via tsx) + `next build`, which
       # type-checks the project. The e2e workflow only runs `next dev`, so
       # type/build/prebuild errors (e.g. the TypeScript 6 upgrade) are invisible
       # to it and only surface on Vercel. This job mirrors the Vercel build.
       - name: Build
         run: npm run build
+
+      - name: Check mobile performance budget
+        run: npm run performance:check

--- a/README.md
+++ b/README.md
@@ -16,10 +16,11 @@ npm run build
 npm run performance:check
 ```
 
-The check reads Next.js's production build manifest and caps initial homepage
-JavaScript at 185 KiB gzip across at most nine requests, with no initial chunk
-larger than 65 KiB gzip. These limits protect mobile transfer and parse costs
-without using a Lighthouse score as a flaky CI gate.
+The check reads Next.js's production build manifest, including its
+low-priority build metadata scripts, and caps initial homepage JavaScript at
+185 KiB gzip across at most 13 requests, with no initial chunk larger than 65
+KiB gzip. These limits protect mobile transfer and parse costs without using a
+Lighthouse score as a flaky CI gate.
 
 The chat launcher remains in the initial page, while its interactive
 implementation downloads on first activation. Google Analytics remains loaded

--- a/README.md
+++ b/README.md
@@ -5,3 +5,24 @@
 - Styled with EmotionJS💅🏾
 - Written in TypeScript ⚛
 - Project and Book content types 🖊
+
+## Mobile performance budget
+
+Run a production build, then check the deterministic homepage JavaScript
+budget:
+
+```sh
+npm run build
+npm run performance:check
+```
+
+The check reads Next.js's production build manifest and caps initial homepage
+JavaScript at 185 KiB gzip across at most nine requests, with no initial chunk
+larger than 65 KiB gzip. These limits protect mobile transfer and parse costs
+without using a Lighthouse score as a flaky CI gate.
+
+The chat launcher remains in the initial page, while its interactive
+implementation downloads on first activation. Google Analytics remains loaded
+asynchronously, Vercel Analytics remains enabled, and Prism's third-party theme
+stylesheet remains in place; the budget detects future growth without removing
+site telemetry or syntax highlighting.

--- a/components/chat/chat-launcher.styles.ts
+++ b/components/chat/chat-launcher.styles.ts
@@ -1,0 +1,52 @@
+import styled from '@emotion/styled';
+
+export const ChatContainer = styled.div`
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 1000;
+  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
+
+  @media (max-width: 560px) {
+    bottom: 16px;
+    right: 16px;
+  }
+`;
+
+export const ChatButton = styled.button`
+  width: 56px;
+  height: 56px;
+  border-radius: 50%;
+  background: var(--chat-header-bg, #154475);
+  border: none;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  transition:
+    transform var(--transition-duration, 0.25s)
+      var(--transition-timing-function, cubic-bezier(0.16, 1, 0.3, 1)),
+    box-shadow var(--transition-duration, 0.25s)
+      var(--transition-timing-function, cubic-bezier(0.16, 1, 0.3, 1));
+
+  &:hover {
+    transform: scale(1.05);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
+  }
+
+  &:focus {
+    outline: 2px solid var(--chat-header-bg, #154475);
+    outline-offset: 2px;
+  }
+
+  &:disabled {
+    cursor: wait;
+  }
+
+  svg {
+    width: 24px;
+    height: 24px;
+    fill: white;
+  }
+`;

--- a/components/chat/chat-widget.styles.ts
+++ b/components/chat/chat-widget.styles.ts
@@ -1,52 +1,5 @@
 import styled from '@emotion/styled';
 
-export const ChatContainer = styled.div`
-  position: fixed;
-  bottom: 24px;
-  right: 24px;
-  z-index: 1000;
-  font-family: var(--font-dm-sans), 'DM Sans', sans-serif;
-
-  @media (max-width: 560px) {
-    bottom: 16px;
-    right: 16px;
-  }
-`;
-
-export const ChatButton = styled.button`
-  width: 56px;
-  height: 56px;
-  border-radius: 50%;
-  background: var(--chat-header-bg, #154475);
-  border: none;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
-  transition:
-    transform var(--transition-duration, 0.25s)
-      var(--transition-timing-function, cubic-bezier(0.16, 1, 0.3, 1)),
-    box-shadow var(--transition-duration, 0.25s)
-      var(--transition-timing-function, cubic-bezier(0.16, 1, 0.3, 1));
-
-  &:hover {
-    transform: scale(1.05);
-    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.2);
-  }
-
-  &:focus {
-    outline: 2px solid var(--chat-header-bg, #154475);
-    outline-offset: 2px;
-  }
-
-  svg {
-    width: 24px;
-    height: 24px;
-    fill: white;
-  }
-`;
-
 export const ChatPanel = styled.div`
   position: absolute;
   bottom: 70px;

--- a/components/chat/chat-widget.tsx
+++ b/components/chat/chat-widget.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
+import { ChatButton, ChatContainer } from './chat-launcher.styles';
 import {
-  ChatContainer,
-  ChatButton,
   ChatPanel,
   ChatHeader,
   ChatMessages,
@@ -23,19 +22,29 @@ interface ChatMessage {
 }
 
 const ChatIcon = () => (
-  <svg viewBox="0 0 24 24" fill="currentColor">
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
     <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z" />
   </svg>
 );
 
 const CloseIcon = () => (
-  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    aria-hidden="true"
+  >
     <path d="M18 6L6 18M6 6l12 12" />
   </svg>
 );
 
-const ChatWidget: React.FC = () => {
-  const [isOpen, setIsOpen] = useState(false);
+interface ChatWidgetProps {
+  initiallyOpen?: boolean;
+}
+
+const ChatWidget: React.FC<ChatWidgetProps> = ({ initiallyOpen = false }) => {
+  const [isOpen, setIsOpen] = useState(initiallyOpen);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/components/chat/index.ts
+++ b/components/chat/index.ts
@@ -1,1 +1,1 @@
-export { default as ChatWidget } from './chat-widget';
+export { default as ChatWidget } from './lazy-chat-widget';

--- a/components/chat/lazy-chat-widget.tsx
+++ b/components/chat/lazy-chat-widget.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+
+import { ChatButton, ChatContainer } from './chat-launcher.styles';
+
+type LoadedChatWidget = React.ComponentType<{ initiallyOpen?: boolean }>;
+
+const ChatIcon = () => (
+  <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+    <path d="M20 2H4c-1.1 0-2 .9-2 2v18l4-4h14c1.1 0 2-.9 2-2V4c0-1.1-.9-2-2-2zm0 14H6l-2 2V4h16v12z" />
+  </svg>
+);
+
+const LazyChatWidget: React.FC = () => {
+  const [ChatWidget, setChatWidget] = useState<LoadedChatWidget | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadChat = async () => {
+    if (isLoading) return;
+
+    setIsLoading(true);
+    try {
+      const chatModule = await import('./chat-widget');
+      setChatWidget(() => chatModule.default);
+    } catch {
+      setIsLoading(false);
+    }
+  };
+
+  if (ChatWidget) {
+    return <ChatWidget initiallyOpen />;
+  }
+
+  return (
+    <ChatContainer>
+      <ChatButton
+        type="button"
+        onClick={loadChat}
+        aria-label={isLoading ? 'Loading chat' : 'Open chat'}
+        aria-busy={isLoading}
+        disabled={isLoading}
+      >
+        <ChatIcon />
+      </ChatButton>
+    </ChatContainer>
+  );
+};
+
+export default LazyChatWidget;

--- a/config/performance-budget.json
+++ b/config/performance-budget.json
@@ -1,0 +1,6 @@
+{
+  "route": "/",
+  "maxInitialJavaScriptGzipKiB": 185,
+  "maxInitialJavaScriptRequests": 9,
+  "maxInitialChunkGzipKiB": 65
+}

--- a/config/performance-budget.json
+++ b/config/performance-budget.json
@@ -1,6 +1,6 @@
 {
   "route": "/",
   "maxInitialJavaScriptGzipKiB": 185,
-  "maxInitialJavaScriptRequests": 9,
+  "maxInitialJavaScriptRequests": 13,
   "maxInitialChunkGzipKiB": 65
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:unit": "tsx --test tests/**/*.test.ts",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui --ui-host 127.0.0.1",
+    "performance:check": "tsx scripts/check-performance-budget.ts",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "generate:context": "tsx scripts/generate-chat-context.ts",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./tests",
+  testMatch: "**/*.spec.ts",
   fullyParallel: true,
   timeout: 30_000,
   expect: {

--- a/scripts/check-performance-budget.ts
+++ b/scripts/check-performance-budget.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { gzipSync } from 'node:zlib';
+
+interface PerformanceBudget {
+  route: string;
+  maxInitialJavaScriptGzipKiB: number;
+  maxInitialJavaScriptRequests: number;
+  maxInitialChunkGzipKiB: number;
+}
+
+interface BuildManifest {
+  pages: Record<string, string[]>;
+  polyfillFiles?: string[];
+  rootMainFiles?: string[];
+}
+
+interface ChunkMeasurement {
+  file: string;
+  gzipKiB: number;
+}
+
+const parseArgument = (name: string, fallback: string): string => {
+  const argumentIndex = process.argv.indexOf(name);
+  return argumentIndex === -1 ? fallback : process.argv[argumentIndex + 1];
+};
+
+const formatKiB = (value: number): string => value.toFixed(1);
+
+const buildDir = path.resolve(parseArgument('--build-dir', '.next'));
+const configPath = path.resolve(
+  parseArgument('--config', 'config/performance-budget.json')
+);
+const budget = JSON.parse(
+  readFileSync(configPath, 'utf8')
+) as PerformanceBudget;
+const manifest = JSON.parse(
+  readFileSync(path.join(buildDir, 'build-manifest.json'), 'utf8')
+) as BuildManifest;
+
+const routeFiles = manifest.pages[budget.route];
+const appFiles = manifest.pages['/_app'];
+if (!routeFiles || !appFiles) {
+  throw new Error(
+    `Build manifest must contain /_app and ${budget.route} page assets`
+  );
+}
+
+const initialJavaScriptFiles = [
+  ...(manifest.polyfillFiles ?? []),
+  ...(manifest.rootMainFiles ?? []),
+  ...appFiles,
+  ...routeFiles,
+].filter(
+  (file, index, files) => file.endsWith('.js') && files.indexOf(file) === index
+);
+
+const chunks: ChunkMeasurement[] = initialJavaScriptFiles.map((file) => {
+  const source = readFileSync(path.join(buildDir, file));
+  return {
+    file,
+    gzipKiB: gzipSync(source, { level: 9 }).byteLength / 1024,
+  };
+});
+const totalGzipKiB = chunks.reduce((total, chunk) => total + chunk.gzipKiB, 0);
+const largestChunk = chunks.reduce(
+  (largest, chunk) => (chunk.gzipKiB > largest.gzipKiB ? chunk : largest),
+  { file: '(none)', gzipKiB: 0 }
+);
+
+const measurements = [
+  `total initial JavaScript: ${formatKiB(totalGzipKiB)} KiB gzip / ${budget.maxInitialJavaScriptGzipKiB} KiB`,
+  `initial JavaScript requests: ${chunks.length} / ${budget.maxInitialJavaScriptRequests}`,
+  `largest initial JavaScript chunk: ${formatKiB(largestChunk.gzipKiB)} KiB gzip / ${budget.maxInitialChunkGzipKiB} KiB (${largestChunk.file})`,
+];
+const violations = [
+  totalGzipKiB > budget.maxInitialJavaScriptGzipKiB ? measurements[0] : null,
+  chunks.length > budget.maxInitialJavaScriptRequests ? measurements[1] : null,
+  largestChunk.gzipKiB > budget.maxInitialChunkGzipKiB ? measurements[2] : null,
+].filter((violation): violation is string => violation !== null);
+
+if (violations.length > 0) {
+  console.error(
+    [`Performance budget failed for ${budget.route}:`, ...violations]
+      .map((line) => `  ${line}`)
+      .join('\n')
+  );
+  process.exitCode = 1;
+} else {
+  console.log(
+    [`Performance budget passed for ${budget.route}:`, ...measurements]
+      .map((line) => `  ${line}`)
+      .join('\n')
+  );
+}

--- a/scripts/check-performance-budget.ts
+++ b/scripts/check-performance-budget.ts
@@ -11,6 +11,7 @@ interface PerformanceBudget {
 
 interface BuildManifest {
   pages: Record<string, string[]>;
+  lowPriorityFiles?: string[];
   polyfillFiles?: string[];
   rootMainFiles?: string[];
 }
@@ -51,6 +52,7 @@ const initialJavaScriptFiles = [
   ...(manifest.rootMainFiles ?? []),
   ...appFiles,
   ...routeFiles,
+  ...(manifest.lowPriorityFiles ?? []),
 ].filter(
   (file, index, files) => file.endsWith('.js') && files.indexOf(file) === index
 );

--- a/tests/chat-lazy-loading.spec.ts
+++ b/tests/chat-lazy-loading.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from '@playwright/test';
+
+test('loads the chat implementation only after launcher activation', async ({
+  page,
+}) => {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+
+  const deferredScriptRequests: string[] = [];
+  page.on('request', (request) => {
+    if (request.resourceType() === 'script') {
+      deferredScriptRequests.push(request.url());
+    }
+  });
+
+  await page.getByRole('button', { name: 'Open chat' }).click();
+
+  await expect
+    .poll(() => deferredScriptRequests.length, { timeout: 5_000 })
+    .toBeGreaterThan(0);
+  await expect(
+    page.getByRole('dialog', { name: 'Chat with Ryan' })
+  ).toBeVisible();
+});

--- a/tests/performance-budget.test.ts
+++ b/tests/performance-budget.test.ts
@@ -34,6 +34,11 @@ const createBuildFixture = () => {
         '/_app': ['static/chunks/shared.js'],
         '/': ['static/chunks/shared.js', 'static/chunks/home.js'],
       },
+      lowPriorityFiles: [
+        'static/build-id/_buildManifest.js',
+        'static/build-id/_ssgManifest.js',
+        'static/build-id/_clientMiddlewareManifest.js',
+      ],
       polyfillFiles: [],
       rootMainFiles: [],
     })
@@ -45,6 +50,20 @@ const createBuildFixture = () => {
   writeFileSync(
     path.join(chunksDir, 'home.js'),
     'const home = "homepage-code";\n'.repeat(20)
+  );
+  const buildMetadataDir = path.join(buildDir, 'static', 'build-id');
+  mkdirSync(buildMetadataDir, { recursive: true });
+  writeFileSync(
+    path.join(buildMetadataDir, '_buildManifest.js'),
+    'self.__BUILD_MANIFEST = {};\n'
+  );
+  writeFileSync(
+    path.join(buildMetadataDir, '_ssgManifest.js'),
+    'self.__SSG_MANIFEST = new Set();\n'
+  );
+  writeFileSync(
+    path.join(buildMetadataDir, '_clientMiddlewareManifest.js'),
+    'self.__MIDDLEWARE_MANIFEST = [];\n'
   );
 
   return { fixtureRoot, buildDir };
@@ -79,13 +98,31 @@ test('passes when initial JavaScript stays within every configured budget', () =
     const result = runChecker(buildDir, {
       route: '/',
       maxInitialJavaScriptGzipKiB: 10,
-      maxInitialJavaScriptRequests: 2,
+      maxInitialJavaScriptRequests: 5,
       maxInitialChunkGzipKiB: 10,
     });
 
     assert.equal(result.status, 0, result.stderr);
     assert.match(result.stdout, /Performance budget passed for \//);
-    assert.match(result.stdout, /initial JavaScript requests: 2 \/ 2/);
+    assert.match(result.stdout, /initial JavaScript requests: 5 \/ 5/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('fails when low-priority initial scripts push the request count over budget', () => {
+  const { fixtureRoot, buildDir } = createBuildFixture();
+
+  try {
+    const result = runChecker(buildDir, {
+      route: '/',
+      maxInitialJavaScriptGzipKiB: 10,
+      maxInitialJavaScriptRequests: 4,
+      maxInitialChunkGzipKiB: 10,
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /initial JavaScript requests: 5 \/ 4/);
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
   }

--- a/tests/performance-budget.test.ts
+++ b/tests/performance-budget.test.ts
@@ -1,0 +1,113 @@
+import assert from 'node:assert/strict';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+const projectRoot = path.resolve(process.cwd());
+const checkerPath = path.join(
+  projectRoot,
+  'scripts',
+  'check-performance-budget.ts'
+);
+const tsxPath = path.join(
+  projectRoot,
+  'node_modules',
+  'tsx',
+  'dist',
+  'cli.mjs'
+);
+
+const createBuildFixture = () => {
+  const fixtureRoot = mkdtempSync(
+    path.join(tmpdir(), 'portfolio-performance-budget-')
+  );
+  const buildDir = path.join(fixtureRoot, '.next');
+  const chunksDir = path.join(buildDir, 'static', 'chunks');
+  mkdirSync(chunksDir, { recursive: true });
+
+  writeFileSync(
+    path.join(buildDir, 'build-manifest.json'),
+    JSON.stringify({
+      pages: {
+        '/_app': ['static/chunks/shared.js'],
+        '/': ['static/chunks/shared.js', 'static/chunks/home.js'],
+      },
+      polyfillFiles: [],
+      rootMainFiles: [],
+    })
+  );
+  writeFileSync(
+    path.join(chunksDir, 'shared.js'),
+    'const shared = "shared-runtime";\n'.repeat(20)
+  );
+  writeFileSync(
+    path.join(chunksDir, 'home.js'),
+    'const home = "homepage-code";\n'.repeat(20)
+  );
+
+  return { fixtureRoot, buildDir };
+};
+
+const runChecker = (
+  buildDir: string,
+  budget: {
+    route: string;
+    maxInitialJavaScriptGzipKiB: number;
+    maxInitialJavaScriptRequests: number;
+    maxInitialChunkGzipKiB: number;
+  }
+) => {
+  const configPath = path.join(path.dirname(buildDir), 'budget.json');
+  writeFileSync(configPath, JSON.stringify(budget));
+
+  return spawnSync(
+    process.execPath,
+    [tsxPath, checkerPath, '--build-dir', buildDir, '--config', configPath],
+    {
+      cwd: projectRoot,
+      encoding: 'utf8',
+    }
+  );
+};
+
+test('passes when initial JavaScript stays within every configured budget', () => {
+  const { fixtureRoot, buildDir } = createBuildFixture();
+
+  try {
+    const result = runChecker(buildDir, {
+      route: '/',
+      maxInitialJavaScriptGzipKiB: 10,
+      maxInitialJavaScriptRequests: 2,
+      maxInitialChunkGzipKiB: 10,
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Performance budget passed for \//);
+    assert.match(result.stdout, /initial JavaScript requests: 2 \/ 2/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test('fails with measured details when an initial JavaScript budget is exceeded', () => {
+  const { fixtureRoot, buildDir } = createBuildFixture();
+
+  try {
+    const result = runChecker(buildDir, {
+      route: '/',
+      maxInitialJavaScriptGzipKiB: 0,
+      maxInitialJavaScriptRequests: 1,
+      maxInitialChunkGzipKiB: 0,
+    });
+
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /Performance budget failed for \//);
+    assert.match(result.stderr, /total initial JavaScript/);
+    assert.match(result.stderr, /initial JavaScript requests/);
+    assert.match(result.stderr, /largest initial JavaScript chunk/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- defer the stateful chat implementation until the accessible launcher is activated, while preserving focus handling, loading state, message history, and Enter/Shift+Enter behavior
- add a deterministic production-manifest budget for homepage initial JavaScript: 185 KiB gzip total, 13 requests, and 65 KiB gzip per chunk
- count every Next-managed script emitted into the initial HTML, including `lowPriorityFiles` such as `_buildManifest.js`, `_ssgManifest.js`, and `_clientMiddlewareManifest.js`
- run unit tests, the production build, and the budget check in CI; keep Playwright discovery scoped to E2E specs
- document the command, rationale, and third-party review (Google Analytics, Vercel Analytics, and Prism retained)

## Why these limits
A mobile Lighthouse audit scored 88 with 320 ms total blocking time and about 112 KiB unused JavaScript. Lighthouse scores vary with runtime conditions, so this PR gates reproducible build artifacts instead.

Current production build, including the three low-priority build metadata scripts loaded by the homepage:
- total initial JavaScript: **176.2 KiB gzip / 185 KiB**
- initial Next-managed JavaScript requests: **12 / 13**
- largest initial JavaScript chunk: **63.2 KiB gzip / 65 KiB**

The transfer cap leaves about 5% headroom, the request cap permits one additional initial script, and the per-chunk cap prevents a large parsing regression. The checker deduplicates shared app/route assets before measuring them.

## TDD and verification
- red: budget fixture tests failed before the checker existed
- red: lazy-load E2E observed no post-activation script request with the eager widget
- review regression red: a fixture with three `lowPriorityFiles` reported 2 requests instead of 5 and missed a 5-over-4 request breach
- green: `npm run test:unit` — 45/45 passed
- green: `npm run build` — production build completed
- green: `npm run performance:check` — 176.2 KiB / 12 requests / 63.2 KiB, all within budget
- green: full production-server Playwright suite — 45/45 passed with one worker
- green: focused lazy-chat/accessibility suite — 14/14 passed, including Enter submission and axe checks
- green: `git diff --check`
- touched files were formatted with Prettier; the repository-wide format check still reports 109 pre-existing files on the base branch

Local verification used Node 24.11.1 while CI and the project engine use Node 22.x. The build and E2E server also retain the existing linked-worktree root warning from Next.js.