### PR TITLE
Update portfolio profile

### DIFF
--- a/me/profile.json
+++ b/me/profile.json
@@ -16,7 +16,7 @@
     },
     {
       "company": "Wells Fargo",
-      "title": "Front End Developer",
+      "title": "Software Engineer",
       "start": "Dec 2017",
       "end": "Jul 2021"
     },
@@ -101,6 +101,10 @@
         "React Testing Library",
         "Playwright"
       ]
+    },
+    {
+      "group": "AI",
+      "items": ["Claude Code", "Codex", "Copilot"]
     },
     {
       "group": "Machine Learning",

--- a/me/summary.txt
+++ b/me/summary.txt
@@ -8,7 +8,7 @@ Outside of work I'm usually exploring New York's food scene, cooking, running, t
 
 WORK EXPERIENCE:
 - Nava - Senior Software Engineer (Oct 2021 - Present)
-- Wells Fargo - Front End Developer (Dec 2017 - Jul 2021)
+- Wells Fargo - Software Engineer (Dec 2017 - Jul 2021)
 - Children's Council of San Francisco - Web Developer (Feb 2016 - Dec 2017)
 - Kaiser Permanente Division of Research - Web Developer (Jul 2010 - Feb 2016)
 
@@ -26,6 +26,7 @@ TECHNICAL SKILLS:
 - Backend: Python, Django, Flask, Node.js, GraphQL
 - Databases: PostgreSQL
 - Tools: Docker, Colima, Git, Jest, React Testing Library, Playwright
+- AI: Claude Code, Codex, Copilot
 - Machine Learning: Supervised learning, Unsupervised learning, Reinforcement learning
 
 VOLUNTEERING:


### PR DESCRIPTION
## Summary
- add an AI skills group containing Claude Code, Codex, and Copilot
- refresh portfolio profile information
- regenerate the profile summary used by the portfolio chat assistant

## Verification
- `npm run test:unit` — 46 passed
- `npm run build` — passed, 45 routes generated
- `npm run performance:check` — passed
- `npx playwright test tests/about-page.spec.ts --workers=1` — 6 passed